### PR TITLE
Resolved cohort outputs issue 

### DIFF
--- a/R/run_biomee_f_bysite.R
+++ b/R/run_biomee_f_bysite.R
@@ -563,8 +563,8 @@ run_biomee_f_bysite <- function(
       n                = as.integer(nrow(forcing)), # n here is for hourly (forcing is hourly), add n for daily and annual outputs
       n_daily          = as.integer(n_daily), 
       n_annual         = as.integer(runyears), 
-      #n_annual_cohorts = as.integer(params_siml$nyeartrend), # to get cohort outputs after spinup year
-      n_annual_cohorts = as.integer(runyears), # to get cohort outputs from year 1
+      n_annual_cohorts = as.integer(params_siml$nyeartrend), # to get cohort outputs after spinup year
+      #n_annual_cohorts = as.integer(runyears), # to get cohort outputs from year 1
       forcing          = as.matrix(forcing)
       )
     

--- a/R/run_biomee_f_bysite.R
+++ b/R/run_biomee_f_bysite.R
@@ -561,10 +561,10 @@ run_biomee_f_bysite <- function(
       init_Nmineral    = as.numeric(init_soil$init_Nmineral),
       N_input          = as.numeric(init_soil$N_input),
       n                = as.integer(nrow(forcing)), # n here is for hourly (forcing is hourly), add n for daily and annual outputs
-      n_daily          = as.integer(n_daily), # n here is for hourly (forcing is hourly), add n for daily and annual outputs
-      n_annual         = as.integer(runyears), # n here is for hourly (forcing is hourly), add n for daily and annual outputs
-      #n_annual_cohorts = as.integer(params_siml$nyeartrend), # n here is for hourly (forcing is hourly), add n for daily and annual outputs
-      n_annual_cohorts = as.integer(runyears), # n here is for hourly (forcing is hourly), add n for daily and annual outputs
+      n_daily          = as.integer(n_daily), 
+      n_annual         = as.integer(runyears), 
+      #n_annual_cohorts = as.integer(params_siml$nyeartrend), # to get cohort outputs after spinup year
+      n_annual_cohorts = as.integer(runyears), # to get cohort outputs from year 1
       forcing          = as.matrix(forcing)
       )
     

--- a/src/sofun_r.f90
+++ b/src/sofun_r.f90
@@ -768,9 +768,17 @@ contains
       !----------------------------------------------------------------
       ! Output output_annual_cohorts (without subroutine)
       !----------------------------------------------------------------
-      if (.not. myinterface%steering%spinup) then  ! To get outputs only after spinupyears
 
-        idx =  yr - myinterface%params_siml%spinupyears
+      ! To get outputs only after spinupyears make if below and 
+      ! also in run_biomee_f_bysite.R make n_annual_cohorts = as.integer(params_siml$nyeartrend)
+
+      !if (.not. myinterface%steering%spinup) then  
+
+        !idx =  yr - myinterface%params_siml%spinupyears
+
+      ! To get outputs for all runyears idx=yr and also in run_biomee_f_bysite.R make n_annual_cohorts = as.integer(runyears)
+       
+       idx =  yr
 
         output_annual_cohorts_year(idx, :)        = dble(out_biosphere%annual_cohorts(:)%year)
         output_annual_cohorts_cID(idx, :)         = dble(out_biosphere%annual_cohorts(:)%cID)
@@ -805,7 +813,7 @@ contains
         output_annual_cohorts_Nfix(idx, :)        = dble(out_biosphere%annual_cohorts(:)%Nfix)
         output_annual_cohorts_deathrate(idx, :)   = dble(out_biosphere%annual_cohorts(:)%deathrate)
 
-       end if
+       !end if
 
     end do yearloop
 

--- a/src/sofun_r.f90
+++ b/src/sofun_r.f90
@@ -772,13 +772,13 @@ contains
       ! To get outputs only after spinupyears make if below and 
       ! also in run_biomee_f_bysite.R make n_annual_cohorts = as.integer(params_siml$nyeartrend)
 
-      !if (.not. myinterface%steering%spinup) then  
+      if (.not. myinterface%steering%spinup) then  
 
-        !idx =  yr - myinterface%params_siml%spinupyears
+        idx =  yr - myinterface%params_siml%spinupyears
 
       ! To get outputs for all runyears idx=yr and also in run_biomee_f_bysite.R make n_annual_cohorts = as.integer(runyears)
        
-       idx =  yr
+       !idx =  yr
 
         output_annual_cohorts_year(idx, :)        = dble(out_biosphere%annual_cohorts(:)%year)
         output_annual_cohorts_cID(idx, :)         = dble(out_biosphere%annual_cohorts(:)%cID)
@@ -813,7 +813,7 @@ contains
         output_annual_cohorts_Nfix(idx, :)        = dble(out_biosphere%annual_cohorts(:)%Nfix)
         output_annual_cohorts_deathrate(idx, :)   = dble(out_biosphere%annual_cohorts(:)%deathrate)
 
-       !end if
+       end if
 
     end do yearloop
 


### PR DESCRIPTION
I have noticed that the annual cohort outputs had an error in the year and PFT columns. I have now corrected it and the cohort outputs are saved after the spinup years. You can merge it with the geco/master.