### PR TITLE
Rpeat last year forcing

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -36,7 +36,10 @@
 #'     \describe{
 #'       \item{spinup}{A logical value indicating whether this simulation does spin-up.}
 #'       \item{spinupyears}{Number of spin-up years.}
-#'       \item{recycle}{Length of standard recycling period, in years.}
+#'       \item{recycle}{Length of the recycling period during spin-up, in years.}
+#'       \item{firstyeartrend}{First transient year (year AD).}
+#'       \item{nyeartrend}{Number of transient years. If greater than the forcing data, the last year is repeated.}
+#'       \item{steps_per_day}{Time resolution (day-1). Must be set to 1.}
 #'       \item{outdt}{An integer indicating the output periodicity.}
 #'       \item{ltre}{A logical value, \code{TRUE} if evergreen tree.}
 #'       \item{ltne}{A logical value, \code{TRUE} if evergreen tree and N-fixing.}
@@ -188,9 +191,9 @@
 #'     \describe{
 #'       \item{spinup}{Flag indicating whether this simulation does spin-up.}
 #'       \item{spinupyears}{Number of spin-up years.}
-#'       \item{recycle}{Length of standard recycling period (years).}
-#'       \item{firstyeartrend}{First transient year.}
-#'       \item{nyeartrend}{Number of transient years.}
+#'       \item{recycle}{Length of the recycling period during spin-up, in years.}
+#'       \item{firstyeartrend}{First transient year (year AD).}
+#'       \item{nyeartrend}{Number of transient years. If greater than the forcing data, the last year is repeated.}
 #'       \item{steps_per_day}{Time resolution (day-1).}
 #'       \item{do_U_shaped_mortality}{Flag indicating whether U-shaped
 #'         mortality is used.}
@@ -256,7 +259,7 @@
 #'       \item{phenotype}{Integer set to 0 for deciduous and 1 for evergreen.}
 #'       \item{pt}{Integer indicating the type of plant according to photosynthesis:
 #'         0 for C3; 1 for C4}
-#'       \item{alpha_FR}{Fine root turnonver rate (year\eqn{^{-1}}).}
+#'       \item{alpha_FR}{Fine root turnover rate (year\eqn{^{-1}}).}
 #'       \item{rho_FR}{Material density of fine roots (kg C m\eqn{^{-3}}).}
 #'       \item{root_r}{Radius of the fine roots, in m.}
 #'       \item{root_zeta}{e-folding parameter of root vertical distribution, in m.}

--- a/R/run_pmodel_f_bysite.R
+++ b/R/run_pmodel_f_bysite.R
@@ -166,9 +166,7 @@ run_pmodel_f_bysite <- function(
   
   # predefine variables for CRAN check compliance
   ccov <- temp <- rain <- vpd <- ppfd <- netrad <-
-    fsun <- snow <- co2 <- fapar <- patm <- 
-    nyeartrend_forcing <- firstyeartrend_forcing <-
-    tmin <- tmax <- . <- NULL
+    fsun <- snow <- co2 <- fapar <- patm <- tmin <- tmax <- . <- NULL
   
   # base state, always execute the call
   continue <- TRUE

--- a/man/biomee_gs_leuning_drivers.Rd
+++ b/man/biomee_gs_leuning_drivers.Rd
@@ -13,9 +13,9 @@ A tibble of driver data.
     \describe{
       \item{spinup}{Flag indicating whether this simulation does spin-up.}
       \item{spinupyears}{Number of spin-up years.}
-      \item{recycle}{Length of standard recycling period (years).}
-      \item{firstyeartrend}{First transient year.}
-      \item{nyeartrend}{Number of transient years.}
+      \item{recycle}{Length of the recycling period during spin-up, in years.}
+      \item{firstyeartrend}{First transient year (year AD).}
+      \item{nyeartrend}{Number of transient years. If greater than the forcing data, the last year is repeated.}
       \item{steps_per_day}{Time resolution (day-1).}
       \item{do_U_shaped_mortality}{Flag indicating whether U-shaped
         mortality is used.}
@@ -81,7 +81,7 @@ This data structure can be freely used for documenting the dataset, but must inc
       \item{phenotype}{Integer set to 0 for deciduous and 1 for evergreen.}
       \item{pt}{Integer indicating the type of plant according to photosynthesis:
         0 for C3; 1 for C4}
-      \item{alpha_FR}{Fine root turnonver rate (year\eqn{^{-1}}).}
+      \item{alpha_FR}{Fine root turnover rate (year\eqn{^{-1}}).}
       \item{rho_FR}{Material density of fine roots (kg C m\eqn{^{-3}}).}
       \item{root_r}{Radius of the fine roots, in m.}
       \item{root_zeta}{e-folding parameter of root vertical distribution, in m.}

--- a/man/p_model_drivers.Rd
+++ b/man/p_model_drivers.Rd
@@ -36,7 +36,10 @@ A tibble of driver data:
     \describe{
       \item{spinup}{A logical value indicating whether this simulation does spin-up.}
       \item{spinupyears}{Number of spin-up years.}
-      \item{recycle}{Length of standard recycling period, in years.}
+      \item{recycle}{Length of the recycling period during spin-up, in years.}
+      \item{firstyeartrend}{First transient year (year AD).}
+      \item{nyeartrend}{Number of transient years. If greater than the forcing data, the last year is repeated.}
+      \item{steps_per_day}{Time resolution (day-1). Must be set to 1.}
       \item{outdt}{An integer indicating the output periodicity.}
       \item{ltre}{A logical value, \code{TRUE} if evergreen tree.}
       \item{ltne}{A logical value, \code{TRUE} if evergreen tree and N-fixing.}

--- a/src/forcing_siterun_biomee.mod.f90
+++ b/src/forcing_siterun_biomee.mod.f90
@@ -38,12 +38,17 @@ contains
     integer, intent(in) :: climateyear_idx
 
     ! local variables
-    integer :: idx_start, idx_end, it
+    integer :: idx_start, idx_end, it, forcing_years, idx
 
     ! function return variable
     type(climate_type), dimension(ntstepsyear) :: out_climate
 
-    idx_start = (climateyear_idx - 1) * ntstepsyear + 1
+    forcing_years = size(forcing(:, 1)) / ntstepsyear
+    ! If we are simulating more years than the forcing array contains,
+    ! We repeat the last year of the forcing.
+    idx = MIN(climateyear_idx, forcing_years)
+
+    idx_start = (idx - 1) * ntstepsyear + 1
     idx_end   = idx_start + ntstepsyear - 1
 
     ! This is to read from ORNL file

--- a/src/forcing_siterun_pmodel.mod.f90
+++ b/src/forcing_siterun_pmodel.mod.f90
@@ -59,13 +59,17 @@ contains
     logical, intent(in) :: in_netrad
 
     ! local variables
-    integer :: idx_start, idx_end
-    ! integer, dimension(2) :: shape_forcing
+    integer :: idx_start, idx_end, forcing_years, idx
 
     ! function return variable
     type( climate_type ), dimension(ndayyear) :: out_climate
 
-    idx_start = (climateyear_idx - 1) * ndayyear + 1
+    forcing_years = size(forcing(:, 1)) / ndayyear
+    ! If we are simulating more years than the forcing array contains,
+    ! We repeat the last year of the forcing.
+    idx = MIN(climateyear_idx, forcing_years)
+
+    idx_start = (idx - 1) * ndayyear + 1
     idx_end   = idx_start + ndayyear - 1
     
     ! Test if forcing dimensions are correct
@@ -113,11 +117,16 @@ contains
 
     ! local variables 
     integer :: readyear_idx
-    integer :: idx_start, idx_end
+    integer :: idx_start, idx_end, forcing_years, idx
 
     readyear_idx = forcingyear - firstyeartrend + 1
 
-    idx_start = (readyear_idx - 1) * ndayyear + 1
+    forcing_years = size(forcing(:, 1)) / ndayyear
+    ! If we are simulating more years than the forcing array contains,
+    ! We repeat the last year of the forcing.
+    idx = MIN(readyear_idx, forcing_years)
+
+    idx_start = (idx - 1) * ndayyear + 1
     idx_end   = idx_start + ndayyear - 1
 
     pco2 = sum(real(forcing(idx_start:idx_end, 8)))/ndayyear
@@ -138,9 +147,14 @@ contains
     type( vegcover_type ), dimension(ndayyear) :: out_vegcover
 
     ! local variables 
-    integer :: idx_start, idx_end
+    integer :: idx_start, idx_end, forcing_years, idx
 
-    idx_start = (forcingyear_idx - 1) * ndayyear + 1
+    forcing_years = size(forcing(:, 1)) / ndayyear
+    ! If we are simulating more years than the forcing array contains,
+    ! We repeat the last year of the forcing.
+    idx = MIN(forcingyear_idx, forcing_years)
+
+    idx_start = (idx - 1) * ndayyear + 1
     idx_end   = idx_start + ndayyear - 1
 
     out_vegcover(:)%dfapar = real(forcing(idx_start:idx_end, 9))

--- a/src/params_core.mod.f90
+++ b/src/params_core.mod.f90
@@ -66,7 +66,7 @@ module md_params_core
   real, parameter :: dummy = -9999.0             ! arbitrary dummy value
 
   type outtype_steering
-    integer :: year
+    integer :: year            ! current simulation year
     integer :: climateyear     ! year AD for which climate is read in (recycling during spinup or when climate is held const.)
     integer :: climateyear_idx ! year index for which climate is read in.
     integer :: forcingyear     ! year AD for which forcings are read in (=firstyeartrend during spinup)
@@ -126,7 +126,7 @@ contains
         out_steering%add_ninorg = .false.
       end if
 
-      if (year<=steering%spinupyears) then
+      if (year <= steering%spinupyears) then
         ! during spinup
         out_steering%spinup = .true.
         cycleyear = get_cycleyear( year, steering%spinupyears, steering%recycle )
@@ -139,7 +139,7 @@ contains
         out_steering%spinup          = .false.
         out_steering%climateyear_idx = year - steering%spinupyears
         out_steering%climateyear     = out_steering%climateyear_idx + steering%firstyeartrend - 1
-        out_steering%forcingyear = out_steering%climateyear
+        out_steering%forcingyear     = out_steering%climateyear
         out_steering%forcingyear_idx = out_steering%climateyear_idx
       endif
       out_steering%outyear = year + steering%firstyeartrend - steering%spinupyears - 1
@@ -150,13 +150,13 @@ contains
         out_steering%dofree_alloc = .false.
       end if
 
-      if ( (year==spinupyr_soilequil_1 .or. year==spinupyr_soilequil_2 ) .and. year<=steering%spinupyears) then
+      if ( (year == spinupyr_soilequil_1 .or. year == spinupyr_soilequil_2) .and. year <= steering%spinupyears) then
         out_steering%do_soilequil = .true.
       else
         out_steering%do_soilequil = .false.
       end if
 
-      if ( year<=steering%spinupyears .and. ( year > ( spinupyr_soilequil_1 - steering%recycle ) .and. &
+      if ( year <= steering%spinupyears .and. ( year > ( spinupyr_soilequil_1 - steering%recycle ) .and. &
               year <= spinupyr_soilequil_1 .or. year > ( spinupyr_soilequil_2 - steering%recycle ) .and. &
               year <= spinupyr_soilequil_2 ) ) then
         out_steering%average_soil = .true.
@@ -164,7 +164,7 @@ contains
         out_steering%average_soil = .false.
       end if
 
-      if ( year<=steering%spinupyears .and. year <= spinupyr_soilequil_1 ) then
+      if ( year <= steering%spinupyears .and. year <= spinupyr_soilequil_1 ) then
         out_steering%project_nmin = .true.
       else
         out_steering%project_nmin = .false.


### PR DESCRIPTION
- Last forcing year is repeated ad libitum in case `nyeartrend` is greater than the number of years in the forcing data.
- Update drivers doc