### PR TITLE
Fix nan luluc

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,6 @@
 ^.*-logo\..*$
 ^codemeta\.json$
 ^CRAN-SUBMISSION$
+
+# Debugging
+^\.vscode$

--- a/.vscode/debug.R
+++ b/.vscode/debug.R
@@ -1,0 +1,45 @@
+# Following: https://blog.davisvaughan.com/posts/2022-03-11-using-vs-code-to-debug-r-packages-with-c-code/#setup-function
+# which is a detailed description (but only for mac using llvm)
+# and: https://www.maths.ed.ac.uk/~swood34/RCdebug/RCdebug.html
+# and: https://tdhock.github.io/blog/2019/gdb/
+
+# adding flags: PKG_FFLAGS = -frecursive -fbounds-check -fcheck=all -Wall -Wextra -pedantic -g -O0 -fbacktrace -ffpe-trap=invalid,zero,overflow -finit-real=snan -finit-integer=-9999999 -finit-derived
+# adding flags to reproduce NaN bug: PKG_FFLAGS = -frecursive -fbounds-check -fcheck=all -Wall -Wextra -pedantic -g -O0 -fbacktrace -ffpe-trap=invalid,zero,overflow -finit-real=snan -finit-integer=-9999999
+# building: R CMD build --no-manual --no-build-vignettes rsofun && R CMD INSTALL -c --preclean rsofun_5.0.0.9000.tar.gz 
+
+# TODO: this link: https://stackoverflow.com/a/72580854 could potentially explain how to do it in the Docker where we see the error
+#                  https://github.com/renkun-ken/vscode-rcpp-demo
+#                  https://github.com/renkun-ken/vscode-cpp11-demo
+
+# FOR DEBUGGIN in the act:
+# ~/bin/act -r -W '.github/workflows/test-coverage-debug.yaml'
+
+devtools::clean_dll()
+devtools::load_all()
+# library(rsofun)
+# library(dplyr)
+# library(purrr)
+
+check_NA_output <- function(){
+  # THIS YIELDS OUTPUT UNDER ALL CONDITIONS
+  # print("CASE A: Default: =================================")
+  # drvr <- rsofun::biomee_p_model_drivers
+  # res <- runread_biomee_f(drvr)
+  
+  # print(drvr$params_siml[[1]])
+  # print("output_daily_tile:"); print(tibble(res$data[[1]]$output_daily_tile))
+  # print("output_annual_tile:"); print(tibble(res$data[[1]]$output_annual_tile))
+  # print("output_annual_cohort:"); print(tibble(res$data[[1]]$output_annual_cohort))
+  
+  # THIS YIELDS NA UNDER CERTAIN CONDITIONS
+  print("CASE B: spinupyears=0: =================================")
+  drvr <- rsofun::biomee_p_model_drivers |> 
+    mutate(params_siml = purrr::map(params_siml, ~mutate(.x, spinupyears=0)))
+  res <- runread_biomee_f(drvr)
+  
+  print(drvr$params_siml[[1]])
+  print("output_daily_tile:"); print(tibble(res$data[[1]]$output_daily_tile))
+  # print("output_annual_tile:"); print(tibble(res$data[[1]]$output_annual_tile))
+  # print("output_annual_cohort:"); print(tibble(res$data[[1]]$output_annual_cohort))
+}
+check_NA_output()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug R-Fortran",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "/usr/lib/R/bin/exec/R",
+            "args": [
+                "--vanilla",
+                "-e",
+                "source('.vscode/debug.R')"
+              ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {"name":"R_HOME", "value":"/usr/lib/R"}],
+            "setupCommands": [
+                {
+                "description": "Enable pretty-printing for gdb",
+                "text": "-enable-pretty-printing",
+                "ignoreFailures": true
+                }
+            ],
+            // "preLaunchTask": "build R pkg (for debugging)"
+        }
+    ]
+}

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,3 @@
-PKG_FFLAGS = -frecursive -fbounds-check -fcheck=all -Wall -Wextra -pedantic -g -O0 -fbacktrace -ffpe-trap=invalid,zero,overflow -finit-real=snan -finit-integer=-9999999 # -finit-derived
-
 # C objects
 C_OBJS = wrappersc.o
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,5 @@
+PKG_FFLAGS = -frecursive -fbounds-check -fcheck=all -Wall -Wextra -pedantic -g -O0 -fbacktrace -ffpe-trap=invalid,zero,overflow -finit-real=snan -finit-integer=-9999999 # -finit-derived
+
 # C objects
 C_OBJS = wrappersc.o
 

--- a/src/biosphere_biomee.mod.f90
+++ b/src/biosphere_biomee.mod.f90
@@ -19,7 +19,7 @@ module md_biosphere_biomee
 contains
 
   subroutine biosphere_annual( &
-    state, &
+    steering_state, &
     climate, &
     vegn &
   )
@@ -31,7 +31,7 @@ contains
     use, intrinsic :: iso_c_binding, only: c_double
 
     ! Input vairables
-    type(outtype_steering), intent(in)  :: state
+    type(outtype_steering), intent(in)  :: steering_state
     type(climate_type), intent(in), dimension(:) :: climate ! Dimension is ndayyear * steps_per_day
     type(vegn_tile_type), intent(inout) :: vegn
 
@@ -91,7 +91,7 @@ contains
       !-------------------------------------------------
 
       ! sum over fast time steps and cohorts
-      call daily_diagnostics( vegn, state%year, doy, state%daily_reporting)
+      call daily_diagnostics( vegn, steering_state%year, doy, steering_state%daily_reporting)
 
       ! Determine start and end of season and maximum leaf (root) mass
       call vegn_phenology( vegn )
@@ -106,7 +106,7 @@ contains
     !----------------------------------------------------------------
 
     !===== Get annual diagnostics
-    call vegn%annual_diagnostics(state%year, state%cohort_reporting)
+    call vegn%annual_diagnostics(steering_state%year, steering_state%cohort_reporting)
 
     !===== Reproduction and mortality
     ! Kill all individuals in a cohort if NSC falls below critical point
@@ -125,7 +125,7 @@ contains
     call vegn%reduce()
 
     !===== Update post-mortality metrics
-    call vegn%annual_diagnostics_post_mortality(state%cohort_reporting)
+    call vegn%annual_diagnostics_post_mortality(steering_state%cohort_reporting)
 
   end subroutine biosphere_annual
 

--- a/src/biosphere_pmodel.mod.f90
+++ b/src/biosphere_pmodel.mod.f90
@@ -45,7 +45,7 @@ contains
     !----------------------------------------------------------------
     ! INITIALISATIONS
     !----------------------------------------------------------------
-    if (myinterface%steering%init) then
+    if (myinterface%steering_state%init) then
 
       ! set to true on first simulation year and first day
       init_daily = .true.
@@ -88,7 +88,7 @@ contains
         doy=doy+1
 
         ! if (verbose) print*,'----------------------'
-        ! if (verbose) print*,'YEAR, Doy ', myinterface%steering%year, doy
+        ! if (verbose) print*,'YEAR, Doy ', myinterface%steering_state%year, doy
         ! if (verbose) print*,'----------------------'
 
         !----------------------------------------------------------------
@@ -159,8 +159,8 @@ contains
                       tile(:)%soil, &
                       myinterface%climate(:)%dtemp, &
                       doy, &
-                      myinterface%steering%init, &
-                      myinterface%steering%finalize &
+                      myinterface%steering_state%init, &
+                      myinterface%steering_state%finalize &
                       )
         ! if (verbose) print*, '... done'
 

--- a/src/interface_biosphere_pmodel.mod.f90
+++ b/src/interface_biosphere_pmodel.mod.f90
@@ -37,7 +37,7 @@ module md_interface_pmodel
     type(climate_type), dimension(ndayyear) :: climate
     type(vegcover_type), dimension(ndayyear):: vegcover
     ! type(domaininfo_type)                 :: domaininfo
-    type(outtype_steering)                  :: steering
+    type(outtype_steering)                  :: steering_state
     type(paramstype_siml_pmodel)            :: params_siml
     real, dimension(npft)                   :: fpc_grid        ! allocatable because we don't know number of PFTs a priori
     type(paramstype_calib)                  :: params_calib    ! calibratable parameters

--- a/src/interface_in_biosphere_biomee.mod.f90
+++ b/src/interface_in_biosphere_biomee.mod.f90
@@ -43,7 +43,7 @@ module md_interface_in_biomee
 
   type params_siml_biomee
 
-    type(steering_parameters) :: steering
+    type(steering_parameters) :: steering_params
     logical :: do_U_shaped_mortality
     logical :: do_closedN_run
     character(len=30) :: method_photosynth
@@ -250,18 +250,18 @@ contains
     class(params_siml_biomee), intent(inout) :: self
     real(kind=c_double), dimension(nvars_params_siml), intent(in) :: params_siml
 
-    self%steering%do_spinup        = int(params_siml(1)) /= 0
-    self%steering%spinupyears      = int(params_siml(2))
-    self%steering%recycle          = int(params_siml(3))
-    self%steering%firstyeartrend   = int(params_siml(4))
-    self%steering%nyeartrend       = int(params_siml(5))
+    self%steering_params%do_spinup        = int(params_siml(1)) /= 0
+    self%steering_params%spinupyears      = int(params_siml(2))
+    self%steering_params%recycle          = int(params_siml(3))
+    self%steering_params%firstyeartrend   = int(params_siml(4))
+    self%steering_params%nyeartrend       = int(params_siml(5))
 
-    if (self%steering%do_spinup) then
-      self%steering%runyears = self%steering%nyeartrend &
-              + self%steering%spinupyears
+    if (self%steering_params%do_spinup) then
+      self%steering_params%runyears = self%steering_params%nyeartrend &
+              + self%steering_params%spinupyears
     else
-      self%steering%runyears    = self%steering%nyeartrend
-      self%steering%spinupyears = 0
+      self%steering_params%runyears    = self%steering_params%nyeartrend
+      self%steering_params%spinupyears = 0
     endif
 
     ! Simulation parameters
@@ -288,7 +288,7 @@ contains
       self%method_mortality = "bal"
     end select
 
-    self%steering%daily_reporting       = int(params_siml(11)) /= 0
+    self%steering_params%daily_reporting       = int(params_siml(11)) /= 0
 
   end subroutine populate_params_siml
 

--- a/src/interface_out_biosphere_biomee.mod.f90
+++ b/src/interface_out_biosphere_biomee.mod.f90
@@ -161,7 +161,7 @@ module md_interface_out_biomee
 
   !=============== Aggregated tile
 
-  integer, public, parameter :: nvars_aggregated_out = 62
+  integer, public, parameter :: nvars_aggregated_out = nvars_annual_tile + 4
 
   integer, public, parameter :: AGGREGATED_TILE_PROD_POOL_1_C = nvars_annual_tile + 1
   integer, public, parameter :: AGGREGATED_TILE_PROD_POOL_1_N = nvars_annual_tile + 2

--- a/src/params_core.mod.f90
+++ b/src/params_core.mod.f90
@@ -126,7 +126,7 @@ contains
       curr_year_steering_state%outyear = year + steering_params%firstyeartrend - steering_params%spinupyears - 1
 
     else
-
+      curr_year_steering_state%spinup = .false.
       curr_year_steering_state%climateyear = year + steering_params%firstyeartrend - 1
       curr_year_steering_state%climateyear_idx = year
       curr_year_steering_state%outyear = curr_year_steering_state%climateyear

--- a/src/params_core.mod.f90
+++ b/src/params_core.mod.f90
@@ -86,7 +86,7 @@ module md_params_core
 
 contains
 
-  pure function get_steering( year, steering ) result( out_steering )
+  pure function get_steering( year, steering_params ) result( curr_year_steering_state )
     !////////////////////////////////////////////////////////////////
     ! Gets variables used for steering simulation for each
     ! simulation year (setting booleans for opening files, doing
@@ -95,64 +95,64 @@ contains
 
     ! arguments
     integer, intent(in) :: year ! simulation year, starts counting from 1, starting at the beginning of spinup
-    type(steering_parameters), intent(in) :: steering
+    type(steering_parameters), intent(in) :: steering_params
 
     ! function return variable
-    type(outtype_steering) :: out_steering
+    type(outtype_steering) :: curr_year_steering_state
 
     ! local variables
     integer :: cycleyear
 
-    out_steering%year = year
+    curr_year_steering_state%year = year
 
-    if (steering%do_spinup) then
+    if (steering_params%do_spinup) then
 
-      if (year <= steering%spinupyears) then
+      if (year <= steering_params%spinupyears) then
         ! during spinup
-        out_steering%spinup = .true.
-        cycleyear = get_cycleyear( year, steering%spinupyears, steering%recycle )
-        out_steering%climateyear = cycleyear + steering%firstyeartrend - 1
-        out_steering%climateyear_idx = cycleyear
-        out_steering%forcingyear = steering%firstyeartrend
-        out_steering%forcingyear_idx  = 1
+        curr_year_steering_state%spinup = .true.
+        cycleyear = get_cycleyear( year, steering_params%spinupyears, steering_params%recycle )
+        curr_year_steering_state%climateyear = cycleyear + steering_params%firstyeartrend - 1
+        curr_year_steering_state%climateyear_idx = cycleyear
+        curr_year_steering_state%forcingyear = steering_params%firstyeartrend
+        curr_year_steering_state%forcingyear_idx  = 1
       else
         ! during transient simulation
-        out_steering%spinup          = .false.
-        out_steering%climateyear_idx = year - steering%spinupyears
-        out_steering%climateyear     = out_steering%climateyear_idx + steering%firstyeartrend - 1
-        out_steering%forcingyear     = out_steering%climateyear
-        out_steering%forcingyear_idx = out_steering%climateyear_idx
+        curr_year_steering_state%spinup          = .false.
+        curr_year_steering_state%climateyear_idx = year - steering_params%spinupyears
+        curr_year_steering_state%climateyear     = curr_year_steering_state%climateyear_idx + steering_params%firstyeartrend - 1
+        curr_year_steering_state%forcingyear     = curr_year_steering_state%climateyear
+        curr_year_steering_state%forcingyear_idx = curr_year_steering_state%climateyear_idx
       endif
-      out_steering%outyear = year + steering%firstyeartrend - steering%spinupyears - 1
+      curr_year_steering_state%outyear = year + steering_params%firstyeartrend - steering_params%spinupyears - 1
 
     else
 
-      out_steering%climateyear = year + steering%firstyeartrend - 1
-      out_steering%climateyear_idx = year
-      out_steering%outyear = out_steering%climateyear
-      out_steering%forcingyear = out_steering%climateyear
-      out_steering%forcingyear_idx = out_steering%climateyear_idx
+      curr_year_steering_state%climateyear = year + steering_params%firstyeartrend - 1
+      curr_year_steering_state%climateyear_idx = year
+      curr_year_steering_state%outyear = curr_year_steering_state%climateyear
+      curr_year_steering_state%forcingyear = curr_year_steering_state%climateyear
+      curr_year_steering_state%forcingyear_idx = curr_year_steering_state%climateyear_idx
 
     endif
 
-    if (out_steering%spinup)  then
-      out_steering%daily_reporting  = .false.
-      out_steering%cohort_reporting = .false.
+    if (curr_year_steering_state%spinup)  then
+      curr_year_steering_state%daily_reporting  = .false.
+      curr_year_steering_state%cohort_reporting = .false.
     else
-      out_steering%daily_reporting  = steering%daily_reporting
-      out_steering%cohort_reporting = .true.
+      curr_year_steering_state%daily_reporting  = steering_params%daily_reporting
+      curr_year_steering_state%cohort_reporting = .true.
     end if
 
     if (year==1) then
-      out_steering%init = .true.
+      curr_year_steering_state%init = .true.
     else
-      out_steering%init = .false.
+      curr_year_steering_state%init = .false.
     endif
 
-    if (year==steering%runyears) then
-      out_steering%finalize = .true.
+    if (year==steering_params%runyears) then
+      curr_year_steering_state%finalize = .true.
     else
-      out_steering%finalize = .false.
+      curr_year_steering_state%finalize = .false.
     end if
 
   end function get_steering

--- a/src/params_core.mod.f90
+++ b/src/params_core.mod.f90
@@ -106,15 +106,15 @@ contains
     curr_year_steering_state%year = year
 
     if (steering_params%do_spinup) then
-
       if (year <= steering_params%spinupyears) then
         ! during spinup
-        curr_year_steering_state%spinup = .true.
         cycleyear = get_cycleyear( year, steering_params%spinupyears, steering_params%recycle )
-        curr_year_steering_state%climateyear = cycleyear + steering_params%firstyeartrend - 1
+
+        curr_year_steering_state%spinup          = .true.
+        curr_year_steering_state%climateyear     = cycleyear + steering_params%firstyeartrend - 1
         curr_year_steering_state%climateyear_idx = cycleyear
-        curr_year_steering_state%forcingyear = steering_params%firstyeartrend
-        curr_year_steering_state%forcingyear_idx  = 1
+        curr_year_steering_state%forcingyear     = steering_params%firstyeartrend
+        curr_year_steering_state%forcingyear_idx = 1
       else
         ! during transient simulation
         curr_year_steering_state%spinup          = .false.
@@ -123,16 +123,14 @@ contains
         curr_year_steering_state%forcingyear     = curr_year_steering_state%climateyear
         curr_year_steering_state%forcingyear_idx = curr_year_steering_state%climateyear_idx
       endif
-      curr_year_steering_state%outyear = year + steering_params%firstyeartrend - steering_params%spinupyears - 1
-
+      curr_year_steering_state%outyear           = year + steering_params%firstyeartrend - steering_params%spinupyears - 1
     else
-      curr_year_steering_state%spinup = .false.
-      curr_year_steering_state%climateyear = year + steering_params%firstyeartrend - 1
+      curr_year_steering_state%spinup          = .false.
+      curr_year_steering_state%climateyear     = year + steering_params%firstyeartrend - 1
       curr_year_steering_state%climateyear_idx = year
-      curr_year_steering_state%outyear = curr_year_steering_state%climateyear
-      curr_year_steering_state%forcingyear = curr_year_steering_state%climateyear
+      curr_year_steering_state%forcingyear     = curr_year_steering_state%climateyear
       curr_year_steering_state%forcingyear_idx = curr_year_steering_state%climateyear_idx
-
+      curr_year_steering_state%outyear         = curr_year_steering_state%climateyear
     endif
 
     if (curr_year_steering_state%spinup)  then

--- a/src/params_siml_pmodel.mod.f90
+++ b/src/params_siml_pmodel.mod.f90
@@ -14,7 +14,7 @@ module md_params_siml_pmodel
   !----------------------------------------------------------------
   type paramstype_siml_pmodel
 
-    type(steering_parameters) :: steering
+    type(steering_parameters) :: steering_params
     integer :: outdt           ! output periodicity
     integer :: outnt           ! number of output time steps per year
     integer :: secs_per_tstep  ! number of seconds per time step (now daily => 60 * 60 * 24)

--- a/src/pmodel.mod.f90
+++ b/src/pmodel.mod.f90
@@ -83,18 +83,18 @@ contains
     !----------------------------------------------------------------
     ! GET SIMULATION PARAMETERS
     !----------------------------------------------------------------
-    myinterface%params_siml%steering%do_spinup      = spinup /= 0
-    myinterface%params_siml%steering%spinupyears    = spinupyears
-    myinterface%params_siml%steering%recycle        = recycle
-    myinterface%params_siml%steering%firstyeartrend = firstyeartrend
-    myinterface%params_siml%steering%nyeartrend     = nyeartrend
+    myinterface%params_siml%steering_params%do_spinup      = spinup /= 0
+    myinterface%params_siml%steering_params%spinupyears    = spinupyears
+    myinterface%params_siml%steering_params%recycle        = recycle
+    myinterface%params_siml%steering_params%firstyeartrend = firstyeartrend
+    myinterface%params_siml%steering_params%nyeartrend     = nyeartrend
 
-    if (myinterface%params_siml%steering%do_spinup) then
-      myinterface%params_siml%steering%runyears = myinterface%params_siml%steering%nyeartrend &
-              + myinterface%params_siml%steering%spinupyears
+    if (myinterface%params_siml%steering_params%do_spinup) then
+      myinterface%params_siml%steering_params%runyears = myinterface%params_siml%steering_params%nyeartrend &
+              + myinterface%params_siml%steering_params%spinupyears
     else
-      myinterface%params_siml%steering%runyears = myinterface%params_siml%steering%nyeartrend
-      myinterface%params_siml%steering%spinupyears = 0
+      myinterface%params_siml%steering_params%runyears = myinterface%params_siml%steering_params%nyeartrend
+      myinterface%params_siml%steering_params%spinupyears = 0
     endif
     
     myinterface%params_siml%in_ppfd            = in_ppfd /= 0
@@ -139,12 +139,12 @@ contains
     !----------------------------------------------------------------
     myinterface%fpc_grid(:) = get_fpc_grid( myinterface%params_siml )
     
-    do yr=1,myinterface%params_siml%steering%runyears
+    do yr=1,myinterface%params_siml%steering_params%runyears
 
       !----------------------------------------------------------------
       ! Define simulations "steering" variables (forcingyear, etc.)
       !----------------------------------------------------------------
-      myinterface%steering = get_steering( yr, myinterface%params_siml%steering )
+      myinterface%steering_state = get_steering( yr, myinterface%params_siml%steering_params )
 
       !----------------------------------------------------------------
       ! Get external (environmental) forcing
@@ -152,7 +152,7 @@ contains
       ! Get climate variables for this year (full fields and 365 daily values for each variable)
       myinterface%climate(:) = getclimate(nt, &
                                           forcing, &
-                                          myinterface%steering%climateyear_idx, &
+                                          myinterface%steering_state%climateyear_idx, &
                                           myinterface%params_siml%in_ppfd,  &
                                           myinterface%params_siml%in_netrad &
                                           )
@@ -160,8 +160,8 @@ contains
       ! Get annual, gobally uniform CO2
       myinterface%pco2 = getco2(  nt, &
                                   forcing, &
-                                  myinterface%steering%forcingyear, &
-                                  myinterface%params_siml%steering%firstyeartrend &
+                                  myinterface%steering_state%forcingyear, &
+                                  myinterface%params_siml%steering_params%firstyeartrend &
                                   )
 
       !----------------------------------------------------------------
@@ -170,7 +170,7 @@ contains
       myinterface%vegcover(:) = getfapar( &
                                         nt, &
                                         forcing, &
-                                        myinterface%steering%forcingyear_idx &
+                                        myinterface%steering_state%forcingyear_idx &
                                         )
 
       !----------------------------------------------------------------
@@ -182,9 +182,9 @@ contains
       !----------------------------------------------------------------
       ! Populate Fortran output array which is passed back to C/R
       !----------------------------------------------------------------
-      if (yr > myinterface%params_siml%steering%spinupyears ) then
+      if (yr > myinterface%params_siml%steering_params%spinupyears ) then
 
-        idx_start = (myinterface%steering%forcingyear_idx - 1) * ndayyear + 1
+        idx_start = (myinterface%steering_state%forcingyear_idx - 1) * ndayyear + 1
         idx_end   = idx_start + ndayyear - 1
 
         output(idx_start:idx_end,1)  = dble(out_biosphere%fapar(:))  


### PR DESCRIPTION
This fixes #290 and renames `state` as `steering_state` since it is *not* representing 'state variables' of the dynamical system we simulate.