### PR TITLE
Fix compilation for Debian (pure-, save- related)

### DIFF
--- a/src/cohort_biomee.mod.f90
+++ b/src/cohort_biomee.mod.f90
@@ -345,7 +345,7 @@ contains
     self%deathrate     = 0.0
   end subroutine reset_cohort
 
-  pure function can_be_merged_with(self, other) result(res)
+  function can_be_merged_with(self, other) result(res)
     !////////////////////////////////////////////////////////////////
     ! Check if the conditions for merging this cohort with cohort 'other' are met.
     ! To cohorts can be merged if they belong to the same species and layer, and have roughly the same size.


### PR DESCRIPTION
This fixes: ./cohort_biomee.mod.f90:365:16: error: A pure subprogram may not have a variable with the SAVE attribute
      associate (spdata => inputs%params_species)
                 ^^^^^^

This can be tested with: rhub::rhub_check(gh_url = "https://github.com/geco-bern/rsofun.git", platforms = "clang19", branch = "fix-for-Debian")