### PR TITLE
Update Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -52,4 +52,4 @@ main_pmodel.mod.o:
 wrappersc.o: pmodel.mod.o biomee.mod.o
 
 clean:
-    @rm -rf *.o *.mod
+	@rm -rf *.o *.mod


### PR DESCRIPTION
Something that ran as part of the installation process might have started more than two child processes (or threads) at the same time.

See https://contributor.r-project.org/cran-cookbook/code_issues.html#problem-10

GPT4.1 advised me: 

> "Your current Makevars already lists many dependencies, but to be robust for multicore (parallel) builds, you must ensure that every .mod.o file lists all .mod.o files for every module it uses, directly or indirectly.
> 
> *All modules now have explicit dependencies for every module they use.
> *Modules with no dependencies are listed with empty rules for clarity and robustness.
> *This will make your package robust to multicore builds on CRAN."