### PR TITLE
Fix NA output

### DIFF
--- a/R/run_pmodel_f_bysite.R
+++ b/R/run_pmodel_f_bysite.R
@@ -364,7 +364,7 @@ run_pmodel_f_bysite <- function(
       forcing                   = as.matrix(forcing)
     )
   } else {
-    pmodelout <- array(dim = c(1,19), data = NA_real_)
+    pmodelout <- NA_real_
   }
 
   out <- build_out_pmodel(pmodelout, params_siml$firstyeartrend, params_siml$nyeartrend)
@@ -383,7 +383,11 @@ build_out_pmodel <- function(pmodelout, firstyeartrend, nyeartrend){
     yrstart = firstyeartrend,
     yrend = firstyeartrend + nyeartrend - 1,
     noleap = TRUE)
+
+  # create NA output if continue == FALSE (ensure 21 corresponds to column names below)
+  if (all(is.na(pmodelout))) { pmodelout <- array(dim = c(1,21), data = NA_real_) }
   
+  # Prepare output
   out <- pmodelout %>%
     as.matrix() %>% 
     as.data.frame() %>% 


### PR DESCRIPTION
There was a mismatch in number of columns when model was not run. It should be increased from 19 to 21.
This is corrected and also the code is slightly refactored for easier maintenance.

NOTE: Moreover, there is undefined behavior of the longwave radiation balance when ccov is specified as NA, which is allowed currently.
~~This needs to be resolved before merging this PR.~~
This will currently be kept undefined (i.e. when specifying `ccov` as NA, certain quantities linked to the longwave radiation balance are returned as NA (`aet`,`le`,`pet`,`wscal`,`tsoil`,`netrad`,`wcont`,`cond`), whereas `gpp` is still computed based on the prescribed `ppfd`). It will be resolved when the `phydro` branch is merged.