### PR TITLE
Add PROTECT to dims

### DIFF
--- a/src/wrappersc.c
+++ b/src/wrappersc.c
@@ -224,11 +224,11 @@ extern SEXP biomee_f_C(
 
     // Dimensions
     int pDims[4] = {50, nt_annual_trans, 35, n_lu};
-    SEXP dims = allocVector(INTSXP, 4);
+    SEXP dims = PROTECT( allocVector(INTSXP, 4) );
     // INTEGER(dims) is a int* which we initialise with pDims
     memcpy(INTEGER(dims), pDims, 4 * sizeof(int));
     // Allocate 4D array
-    SEXP output_annual_cohort_tile = PROTECT(allocArray(REALSXP, dims));
+    SEXP output_annual_cohort_tile = PROTECT( allocArray(REALSXP, dims) );
 
     SEXP output_annual_aggregated  = PROTECT( allocMatrix(REALSXP, nt_annual, 71) );
     /****************/
@@ -263,7 +263,7 @@ extern SEXP biomee_f_C(
     SET_VECTOR_ELT(out_list, 2, output_annual_cohort_tile);
     SET_VECTOR_ELT(out_list, 3, output_annual_aggregated);
 
-    UNPROTECT(5);
+    UNPROTECT(6);
 
     return out_list;
 }


### PR DESCRIPTION
An issue with rchk popped up. CRAN still passing but might need to be addressed:
```
Function biomee_f_C
  [UP] calling allocating function Rf_allocArray(?,V) with a fresh pointer (dims <arg 2>) rsofun/src/wrappersc.c:231
```
See results: https://cran.r-project.org/web/checks/check_results_rsofun.html
See documentation: https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md


In spite of the location of the error shown at line `231`, I can make the `rchk` pass locally (in [a Docker container](https://github.com/kalibera/rchk/blob/master/doc/DOCKER.md))
```bash
cd GitHub

# setup docker container for local testing
docker pull kalibera/rchk:latest

# check the current CRAN release: (should error)
docker run --rm kalibera/rchk:latest rsofun

# check the local version of the package (../geco-bern/rsofun)
mkdir packages
cd ../GitHub/packages 
R CMD build ../../GitHub/geco-bern/rsofun
cd ../../GitHub
docker run --rm -v `pwd`/packages:/rchk/packages kalibera/rchk:latest /rchk/packages/rsofun_5.1.0.9000.tar.gz
```
when adding a `PROTECT` statement to `dims`:
```
SEXP dims = PROTECT( allocVector(INTSXP, 4) );
...
UNPROTECT(6);
```

@marcadella, is it as simple as that?