### PR TITLE
Add leaf lifespan as LMA indep parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,10 @@
   * Cohorts are now less aggressively merged. Merging criteria was simplified from
   relative to absolute DBH difference. Now merging if difference <= 0.01 m.
   * Removed dummy parameters in `params_species` for `run_biomee_f_bysite()`: 
-  `phenotype`,`Vmax`,`alphaBM`,`leafLS`,`lAImax`,`CNleaf0`.
+  `phenotype`,`Vmax`,`alphaBM`,`lAImax`,`CNleaf0`.
   If still provided, they must be NA, otherwise an error occurs.
+  * Activate `leafLS` as `params_species` parameter (was previously using hardcoded 
+  value of 28.57*LMA ≈ 1.4 to 4.9 years depending on LMA.).
 
 # rsofun 5.1.0
 

--- a/R/data.R
+++ b/R/data.R
@@ -288,7 +288,7 @@
 #'       \item{mortrate_d_u}{Understory tree mortality rate (yr\eqn{^{-1}}).}
 #'     }}\item{The following columns pertaining to the \bold{leaf parameters}:}{\describe{
 #'       \item{LMA}{Leaf mass per unit area (kg C m\eqn{^{-2}}).}
-#'       \item{leafLS}{TODO: unused. leafLS is overwritten by on Fortran level.}
+#'       \item{leafLS}{Leaf life span, (yr). If leafLS > 1.0 year, phenotype is set to evergreen.}
 #'       \item{LNbase}{Basal leaf N per unit area, in kg N m\eqn{^{-2}}.}
 #'       \item{CNleafsupport}{TODO}
 #'       \item{rho_wood}{Wood density (kg C m\eqn{^{-3}}).}

--- a/R/run_biomee_f_bysite.R
+++ b/R/run_biomee_f_bysite.R
@@ -509,7 +509,7 @@ build_params_species <- function(params_species){
   # Ensure certain unused legacy parameters (if provided) are NA.
   # If any other value is received an error is emitted.
   # If not provided set them to NA.
-  must_be_NA_or_missing <- c('phenotype','Vmax','alphaBM','leafLS','lAImax','CNleaf0')
+  must_be_NA_or_missing <- c('phenotype','Vmax','alphaBM','lAImax','CNleaf0')
   
   params_that_should_be_NA <- lapply(
     seq_len(nrow(params_species)), 
@@ -549,6 +549,9 @@ build_params_species <- function(params_species){
   }
   if ('kphio_par_b' %nin% names(params_species)) {
     params_species$kphio_par_b <- 25.0  # optimal temperature of quantum yield efficiency
+  }
+  if ('leafLS' %nin% names(params_species)) {
+    params_species$leafLS <- params_species$LMA * 28.57143 # = LMA * c_LLS
   }
   return(params_species)
 }
@@ -753,7 +756,7 @@ prepare_params_species <- function(params_species){
     "mortrate_d_c",
     "mortrate_d_u",
     "LMA",
-    "leafLS",  # NOTE: dummy parameter, must be NA
+    "leafLS",
     "LNbase",
     "CNleafsupport",
     "rho_wood",

--- a/src/interface_in_biosphere_biomee.mod.f90
+++ b/src/interface_in_biosphere_biomee.mod.f90
@@ -468,7 +468,7 @@ contains
     self%mortrate_d_c       = real( params_species(33))
     self%mortrate_d_u       = real( params_species(34))
     self%LMA                = real( params_species(35)) ! prescribed
-    ! self%leafLS             = real( params_species(36)) ! overridden by self%leafLS = c_LLS * self%LMA
+    self%leafLS             = real( params_species(36))
     self%LNbase             = real( params_species(37))
     self%CNleafsupport      = real( params_species(38))
     self%rho_wood           = real( params_species(39)) ! prescribed
@@ -505,7 +505,6 @@ contains
     ! real    :: root_frac(MAX_LEVELS)              ! root fraction
     ! real    :: SRA                                ! specific fine root area, m2/kg C
     !===== Leaf traits
-    ! real    :: leafLS                             ! leaf life span
     ! real    :: alpha_L                            ! leaf turn over rate, (leaf longevity as a function of LMA)
     ! real    :: LNA                                ! leaf Nitrogen per unit area, kg N/m2
     ! real    :: Vmax                               ! max rubisco rate, mol m-2 s-1

--- a/src/interface_in_biosphere_biomee.mod.f90
+++ b/src/interface_in_biosphere_biomee.mod.f90
@@ -15,9 +15,6 @@ module md_interface_in_biomee
   integer, public, parameter :: MAX_LEVELS = 3  ! Soil layers, for soil water dynamics
   real, public, parameter ::  thksl(MAX_LEVELS) = (/0.05, 0.45, 1.5/)  ! m, thickness of soil layers
 
-  !===== Leaf life span
-  real, parameter  :: c_LLS = 28.57143    ! yr/ (kg C m-2), c_LLS=1/LMAs, where LMAs = 0.035
-
   !===== Number of parameters
   integer, public, parameter :: nvars_params_siml    = 11
   integer, public, parameter :: nvars_site_info      = 4
@@ -542,9 +539,7 @@ contains
     ! CN0 of leaves
     self%LNA = self%LNbase +  self%LMA/self%CNleafsupport
     self%CNleaf0 = self%LMA/self%LNA
-    ! Leaf life span as a function of LMA
-    self%leafLS = c_LLS * self%LMA
-    
+
     call self%init_derived_species_data()
 
   end subroutine init_pft_data
@@ -571,13 +566,16 @@ contains
       self%root_frac(j) = self%root_frac(j) + residual*thksl(j)/rdepth(MAX_LEVELS)
     enddo
 
+    ! Leaf life span as a function of LMA
+    self%leafLS = self%LMA / 0.035 ! 0.035 hardcoded
+    
     if(self%leafLS>1.0)then
       self%phenotype = 1
     else
       self%phenotype = 0
     endif
 
-    ! Leaf turnover rate, (leaf longevity as a function of LMA)
+    ! Leaf turnover rate
     self%alpha_L = 1.0/self%leafLS * self%phenotype
 
   end subroutine init_derived_species_data


### PR DESCRIPTION
This is a PR for an open discussion on how to prescribe leaf life span. Should it be hardcode-linked to LMA or should it be a free parameter?

Currently, leaf lifespan is scaled linearly with leaf mass per area (LMA):
`leafLS = 28.57143 * LMA = LMA / 0.035 ! years`

This is taken over from:
- https://github.com/wengensheng/LM3PPA/blob/3ecc0f070fe16af0157edcb72f0313ac2d9fd494/src/land_lad2/vegetation/vegn_data.F90#L517-L518
- https://github.com/wengensheng/ModelE-BiomeE/blob/17733f2f8523f67b74d5b4000908230be79ea6d1/BiomeE_const.f#L259
- https://github.com/wengensheng/ModelE-BiomeE/blob/17733f2f8523f67b74d5b4000908230be79ea6d1/BiomeE_VEG.f#L554

That means the provided parameter `params_species$leafLS` is effectively inactivated since above relationship is hardcoded in the code.
This PR would be an attempt to activate this parameter.


There is some evidence that leaf life span scales with LMA. Below articles do linear regression between LMA and LLS. However, this is done in the log-log transformed space:
- Osnas 2013 https://www.science.org/doi/10.1126/science.1231574 
- Wang 2023 https://doi.org/10.1126/sciadv.add5667