### PR TITLE
Add configurable prescribed fAPAR and LAI to the CN-model

### DIFF
--- a/R/run_cnmodel_f_bysite.R
+++ b/R/run_cnmodel_f_bysite.R
@@ -1,13 +1,13 @@
 #' R wrapper for SOFUN CN-model
-#' 
+#'
 #' Call to the Fortran CN-model
 #'
 #' @param sitename Site name.
 #' @param params_siml Simulation parameters.
 #' \describe{
-#'       \item{c_only}{A logical specifying whether to simulate interactive C and N cycles. If set to \code{FALSE}, 
-#'                     constant leaf:root allocation fractions are used and required N for allocation is added from 
-#'                     an unspecified source, whereby the N mass balance is violated.} 
+#'       \item{c_only}{A logical specifying whether to simulate interactive C and N cycles. If set to \code{FALSE},
+#'                     constant leaf:root allocation fractions are used and required N for allocation is added from
+#'                     an unspecified source, whereby the N mass balance is violated.}
 #'       \item{spinup}{A logical value indicating whether this simulation does spin-up.}
 #'       \item{spinupyears}{Number of spin-up years.}
 #'       \item{recycle}{Length of standard recycling period, in days.}
@@ -29,12 +29,12 @@
 #'       \item{whc}{A numeric value for the total root zone water holding capacity (in mm), used
 #'       for simulating the soil water balance.}
 #' }
-#' @param forcing A data frame of forcing climate data, used as input 
+#' @param forcing A data frame of forcing climate data, used as input
 #'  (see \code{\link{p_model_drivers}}
 #'  for a detailed description of its structure and contents).
 #' @param params_modl A named list of free (calibratable) model parameters.
 #' \describe{
-#'   \item{kphio}{The quantum yield efficiency at optimal temperature \eqn{\varphi_0}, 
+#'   \item{kphio}{The quantum yield efficiency at optimal temperature \eqn{\varphi_0},
 #'    in mol mol\eqn{^{-1}}.
 #'    When temperature dependence is used, it corresponds to the multiplicative
 #'    parameter \eqn{c} (see Details).}
@@ -49,26 +49,26 @@
 #'    degree-day\eqn{^{-1}}. Larger values produce a sharper transition.}
 #'   \item{kphio_par_e}{Base temperature for accumulating growing degree days
 #'    during recovery from cold hardening, in \eqn{^o}C.}
-#'   \item{soilm_thetastar}{The threshold parameter \eqn{\theta^{*}} in the 
+#'   \item{soilm_thetastar}{The threshold parameter \eqn{\theta^{*}} in the
 #'    soil moisture stress function (see Details), given in mm.
 #'    To turn off the soil moisture stress, set \code{soilm_thetastar = 0}.}
 #'   \item{soilm_betao}{The intercept parameter \eqn{\beta_{0}} in the
-#'    soil moisture stress function (see Details). This is the parameter calibrated 
+#'    soil moisture stress function (see Details). This is the parameter calibrated
 #'    in Stocker et al. 2020 GMD.}
 #'   \item{beta_unitcostratio}{The unit cost of carboxylation, corresponding to
 #'    \eqn{\beta = b / a'} in Eq. 3 of Stocker et al. 2020 GMD.}
 #'   \item{rd_to_vcmax}{Ratio of Rdark (dark respiration) to Vcmax25.}
 #'   \item{tau_acclim}{Acclimation time scale of photosynthesis, in days.}
 #'   \item{kc_jmax}{Parameter for Jmax cost ratio (corresponding to c\eqn{^*} in
-#'   Stocker et al. 2020 GMD).} 
+#'   Stocker et al. 2020 GMD).}
 #' }
-#' @param makecheck A logical specifying whether checks are performed 
+#' @param makecheck A logical specifying whether checks are performed
 #'  to verify forcings and model parameters. \code{TRUE} by default.
 #' @param verbose A logical specifying whether to print warnings.
 #' Defaults to \code{TRUE}.
 #'
 #' @import dplyr
-#' 
+#'
 #' @returns Model output is provided as a tidy dataframe, with columns:
 #' \describe{
 #'   \item{\code{date}}{Date of the observation in YYYY-MM-DD format.}
@@ -76,22 +76,22 @@
 #'      (for example, 2007.000 corresponds to 2007-01-01 and 2007.003 to 2007-01-02.}
 #'   \item{\code{fapar}}{Fraction of photosynthetic active radiation (fAPAR), taking
 #'      values between 0 and 1.}
-#'   \item{\code{gpp}}{Gross Primary Productivity (GPP) for each time stamp 
+#'   \item{\code{gpp}}{Gross Primary Productivity (GPP) for each time stamp
 #'       (in gC m\eqn{^{-2}} d\eqn{^{-1}}).}
 #'   \item{\code{aet}}{Actual evapotranspiration (AET), calculated by SPLASH following Priestly-Taylor (in mm d\eqn{^{-1}}).}
 #'   \item{\code{le}}{Latent heat flux (in J m\eqn{^{-2}} d\eqn{^{-1}}).}
 #'   \item{\code{pet}}{Potential evapotranspiration (PET), calculated by SPLASH following Priestly-Taylor (in mm d\eqn{^{-1}}).}
-#'   \item{\code{vcmax}}{Maximum rate of RuBisCO carboxylation 
+#'   \item{\code{vcmax}}{Maximum rate of RuBisCO carboxylation
 #'       (Vcmax) (in mol C m\eqn{^{-2}} d\eqn{^{-1}}).}
 #'   \item{\code{jmax}}{Maximum rate of electron transport for RuBP regeneration
 #'       (in mol CO\eqn{_2} m\eqn{^{-2}} s\eqn{^{-1}}).}
-#'   \item{\code{vcmax25}}{Maximum rate of carboxylation (Vcmax), 
+#'   \item{\code{vcmax25}}{Maximum rate of carboxylation (Vcmax),
 #'       normalised to 25\eqn{^o}C (in mol C m\eqn{^{-2}} d\eqn{^{-1}}).}
-#'   \item{\code{jmax25}}{Maximum rate of electron transport, normalised to 
+#'   \item{\code{jmax25}}{Maximum rate of electron transport, normalised to
 #'       25\eqn{^o}C (in mol C m\eqn{^{-2}} s\eqn{^{-1}}).}
-#'   \item{\code{gs_accl}}{Acclimated stomatal conductance (in 
+#'   \item{\code{gs_accl}}{Acclimated stomatal conductance (in
 #'       mol C m\eqn{^{-2}} d\eqn{^{-1}} Pa\eqn{^{-1}}).}
-#'   \item{\code{wscal}}{Relative soil water content, between 0 (permanent wilting 
+#'   \item{\code{wscal}}{Relative soil water content, between 0 (permanent wilting
 #'       point, PWP) and 1 (field capacity, FC).}
 #'   \item{\code{chi}}{Ratio of leaf-internal to ambient CO\eqn{_{2}}, ci:ca (unitless).}
 #'   \item{\code{iwue}}{Intrinsic water use efficiency (iWUE) (in Pa).}
@@ -100,39 +100,39 @@
 #'   \item{\code{netrad}}{Net radiation, in W m\eqn{^{-2}}. If not an input driver, calculated by SPLASH.}
 #'   \item{\code{wcont}}{Soil water content, in mm.}
 #'   \item{\code{snow}}{Snow water equivalents, in mm.}
-#'   } 
-#'   
-#' @details Depending on the input model parameters, it's possible to run the 
+#'   }
+#'
+#' @details Depending on the input model parameters, it's possible to run the
 #' different P-model setups presented in Stocker et al. 2020 GMD. The P-model
 #' version implemented in this package allows more flexibility than the one
 #' presented in the paper, with the following functions:
-#' 
+#'
 #' The temperature dependence of the quantum yield efficiency is given by: \cr
 #' \eqn{\varphi_0 (T) = c (1 + a (T - b)^2 ) } if \eqn{0 < c (1 + a (T - b)^2 ) < 1}, \cr
 #' \eqn{\varphi_0 (T) = 0 } if \eqn{ c (1 + a (T - b)^2 ) \leq 0}, and  \cr
 #' \eqn{\varphi_0 (T) = 1 } if \eqn{ c (1 + a (T - b)^2 ) \geq 1}. \cr
 #' The ORG setup can be reproduced by setting \code{kphio_par_a = 0}
 #' and calibrating the \code{kphio} parameter only.
-#' The BRC setup (which calibrates \eqn{c_L = \frac{a_L b_L}{4}} in Eq. 18) is more difficult to reproduce, 
+#' The BRC setup (which calibrates \eqn{c_L = \frac{a_L b_L}{4}} in Eq. 18) is more difficult to reproduce,
 #' since the temperature-dependency has been reformulated and a custom cost
 #' function would be necessary for calibration. The new parameters
 #' are related to \eqn{c_L} as follows: \cr
 #' \eqn{a = -0.0004919819} \cr
 #' \eqn{b = 32.35294} \cr
-#' \eqn{c = 0.6910823 c_L} 
-#' 
+#' \eqn{c = 0.6910823 c_L}
+#'
 #' The soil moisture stress is implemented as \cr
-#' \eqn{\beta(\theta) = \frac{\beta_0 - 1}{{\theta^{*}}^2} 
-#'    (\theta - \theta^{*})^2 + 1 } if 
+#' \eqn{\beta(\theta) = \frac{\beta_0 - 1}{{\theta^{*}}^2}
+#'    (\theta - \theta^{*})^2 + 1 } if
 #'    \eqn{ 0 \leq \theta \leq \theta^{*}} and \cr
 #' \eqn{\beta(\theta) = 1} if \eqn{ \theta > \theta^{*}}. \cr
 #' In Stocker et al. 2020 GMD, the threshold plant-available soil water is set as
-#' \eqn{\theta^{*}} 
+#' \eqn{\theta^{*}}
 #' \code{= 0.6 * whc} where \code{whc} is the site's water holding capacity. Also,
 #' the \eqn{\beta} reduction at low soil moisture (\eqn{\beta_0 = \beta(0)}) was parameterized
 #' as a linear function of mean aridity (Eq. 20 in Stocker et al. 2020 GMD) but is
-#' considered a constant model parameter in this package. 
-#' Hence, the FULL calibration setup cannot be 
+#' considered a constant model parameter in this package.
+#' Hence, the FULL calibration setup cannot be
 #' exactly replicated.
 #'
 #' @export
@@ -152,8 +152,8 @@
 #'   tau_acclim         = 30.0,
 #'   kc_jmax            = 0.41
 #' )
-#' 
-#' # Run the Fortran P-model 
+#'
+#' # Run the Fortran P-model
 #' mod_output <- run_cnmodel_f_bysite(
 #'   # unnest drivers example data
 #'   sitename = p_model_drivers$sitename[1],
@@ -173,13 +173,23 @@ run_cnmodel_f_bysite <- function(
   makecheck = TRUE,
   verbose = TRUE
   ){
-  
+
+  # Backward-compatible defaults for optional canopy forcing
+  if (is.null(params_siml$use_prescribed_fapar)) {
+    params_siml$use_prescribed_fapar <- FALSE
+  }
+
+  if (is.null(params_siml$use_prescribed_lai)) {
+    params_siml$use_prescribed_lai <- FALSE
+  }
+
+
   # predefine variables for CRAN check compliance
   ccov <- temp <- rain <- vpd <- ppfd <- netrad <-
-  fsun <- snow <- co2 <- ndep <- fapar <- patm <- 
+  fsun <- snow <- co2 <- ndep <- fapar <- patm <-
   nyeartrend_forcing <- firstyeartrend_forcing <-
   tmin <- tmax <- fsand <- fclay <- forg <- fgravel <- . <- NULL
-  
+
   # base state, always execute the call
   continue <- TRUE
 
@@ -197,20 +207,20 @@ run_cnmodel_f_bysite <- function(
 
   # Treat NULL inputs and values containing NA/NaN as missing.
   is.nanull <- function(x) is.null(x) || anyNA(x)
-  
-  # record first year and number of years in forcing data 
+
+  # record first year and number of years in forcing data
   # frame (may need to overwrite later)
   ndayyear <- 365
-  
+
   firstyeartrend_forcing <- forcing %>%
     dplyr::ungroup() %>%
     dplyr::slice(1) %>%
     dplyr::pull(date) %>%
     format("%Y") %>%
     as.numeric()
-  
+
   nyeartrend_forcing <- nrow(forcing)/ndayyear
-  
+
   # determine number of seconds per time step
   times <- forcing %>%
     dplyr::pull(date) %>%
@@ -218,14 +228,27 @@ run_cnmodel_f_bysite <- function(
   secs_per_tstep <- difftime(times[1], times[2], units = "secs") %>%
     as.integer() %>%
     abs()
-  
+
+  # Keep the fixed 18-column Fortran forcing interface.
+  # If a canopy variable is simulated internally and is absent from the
+  # forcing data, provide a dummy value that will not be used by the model.
+  if (!params_siml$use_prescribed_fapar &&
+      !"fapar" %in% names(forcing)) {
+    forcing$fapar <- 0.0
+  }
+
+  if (!params_siml$use_prescribed_lai &&
+      !"lai" %in% names(forcing)) {
+    forcing$lai <- 0.0
+  }
+
   # re-define units and naming of forcing dataframe
   # keep the order of columns - it's critical for Fortran (reading by column number)
-  forcing <- forcing %>% 
+  forcing <- forcing %>%
     dplyr::mutate(
       fsun = (100-ccov)/100,
       ndep = 0.0
-      ) %>% 
+      ) %>%
     dplyr::select(
       temp,
       rain,
@@ -249,7 +272,7 @@ run_cnmodel_f_bysite <- function(
 
   # validate input
   if (makecheck){
-    
+
     # list variable to check for
     check_vars <- c(
       "temp",
@@ -257,7 +280,6 @@ run_cnmodel_f_bysite <- function(
       "vpd",
       "snow",
       "co2",
-      "fapar",
       "patm",
       "tmin",
       "tmax",
@@ -265,13 +287,21 @@ run_cnmodel_f_bysite <- function(
       "dno3",
       "dnh4",
       "cseed",
-      "nseed",
-      "lai"
+      "nseed"
     )
-    
+
+    if (params_siml$use_prescribed_fapar) {
+      check_vars <- c(check_vars, "fapar")
+    }
+
+    if (params_siml$use_prescribed_lai) {
+      check_vars <- c(check_vars, "lai")
+    }
+
+
     # create a loop to loop over a list of variables
     # to check validity
-    
+
     data_integrity <- lapply(check_vars, function(check_var){
       if (any(is.nanull(forcing[check_var]))){
         warning(sprintf("Error: Missing value in %s for %s",
@@ -281,11 +311,11 @@ run_cnmodel_f_bysite <- function(
         return(TRUE)
       }
     })
-    
+
     if (suppressWarnings(!all(data_integrity))){
       continue <- FALSE
     }
-    
+
     # parameters to check
     check_param <- c(
       "c_only",
@@ -293,6 +323,8 @@ run_cnmodel_f_bysite <- function(
       "spinupyears",
       "recycle",
       "outdt",
+      "use_prescribed_fapar",
+      "use_prescribed_lai",
       "ltre",
       "ltne",
       "ltnd",
@@ -300,7 +332,7 @@ run_cnmodel_f_bysite <- function(
       "lgn3",
       "lgr4"
     )
-    
+
     parameter_integrity <- lapply(check_param, function(check_var){
       if (any(is.nanull(params_siml[check_var]))){
         warning(sprintf("Error: Missing value in %s for %s",
@@ -310,27 +342,27 @@ run_cnmodel_f_bysite <- function(
         return(TRUE)
       }
     })
-    
+
     if (suppressWarnings(!all(parameter_integrity))){
       continue <- FALSE
     }
-      
+
     if (nrow(forcing) %% ndayyear != 0){
       # something weird more fundamentally -> don't run the model
       warning(" Returning a dummy data frame. Forcing data does not
               correspond to full years.")
       continue <- FALSE
     }
-    
+
     # Check model parameters
-    if( sum( names(params_modl) %in% c('kphio', 
-                                       'kphio_par_a', 
+    if( sum( names(params_modl) %in% c('kphio',
+                                       'kphio_par_a',
                                        'kphio_par_b',
-                                       'soilm_thetastar', 
+                                       'soilm_thetastar',
                                        'soilm_betao',
-                                       'beta_unitcostratio', 
-                                       'rd_to_vcmax', 
-                                       'tau_acclim', 
+                                       'beta_unitcostratio',
+                                       'rd_to_vcmax',
+                                       'tau_acclim',
                                        'kc_jmax',
                                        'f_nretain',
                                        'fpc_tree_max',
@@ -415,27 +447,27 @@ run_cnmodel_f_bysite <- function(
       continue <- FALSE
     }
   }
-  
+
   if (continue){
 
     # determine whether to read PPFD from forcing or to calculate internally
-    in_ppfd <- ifelse(any(is.na(forcing$ppfd)), FALSE, TRUE)  
+    in_ppfd <- ifelse(any(is.na(forcing$ppfd)), FALSE, TRUE)
 
     # determine whether to read PPFD from forcing or to calculate internally
-    in_netrad <- ifelse(any(is.na(forcing$netrad)), FALSE, TRUE)  
-    
+    in_netrad <- ifelse(any(is.na(forcing$netrad)), FALSE, TRUE)
+
     # Check if fsun is available
     if(! (in_ppfd & in_netrad)){
       # fsun must be available when one of ppfd or netrad is missing
       if(any(is.na(forcing$fsun))) continue <- FALSE
     }
   }
-  
+
   if(continue){
-    
+
     # convert to matrix
     forcing <- as.matrix(forcing)
-    
+
     # number of rows in matrix (pre-allocation of memory)
     n <- as.integer(nrow(forcing))
 
@@ -534,7 +566,7 @@ run_cnmodel_f_bysite <- function(
     out <- .Call(
 
       'cnmodel_f_C',
-      
+
       ## Simulation parameters
       c_only                    = as.logical(params_siml$c_only),
       spinup                    = as.logical(params_siml$spinup),
@@ -545,6 +577,8 @@ run_cnmodel_f_bysite <- function(
       secs_per_tstep            = as.integer(secs_per_tstep),
       in_ppfd                   = as.logical(in_ppfd),
       in_netrad                 = as.logical(in_netrad),
+      use_prescribed_fapar      = as.logical(params_siml$use_prescribed_fapar),
+      use_prescribed_lai        = as.logical(params_siml$use_prescribed_lai),
       outdt                     = as.integer(params_siml$outdt),
       ltre                      = as.logical(params_siml$ltre),
       ltne                      = as.logical(params_siml$ltne),
@@ -558,10 +592,10 @@ run_cnmodel_f_bysite <- function(
       altitude                  = as.numeric(site_info$elv),
       whc                       = as.numeric(site_info$whc),
       n                         = n,
-      par                       = par, 
+      par                       = par,
       forcing                   = forcing
       )
-    
+
     # Prepare output to be a nice looking tidy data frame (tibble)
     ddf <- init_dates_dataframe(
       yrstart = firstyeartrend_forcing,
@@ -569,8 +603,8 @@ run_cnmodel_f_bysite <- function(
       noleap = TRUE)
 
     out <- out %>%
-      as.matrix() %>% 
-      as.data.frame() %>% 
+      as.matrix() %>%
+      as.data.frame() %>%
       stats::setNames(
         c(
           "fapar",
@@ -721,7 +755,7 @@ run_cnmodel_f_bysite <- function(
                   x4      = NA
                   )
   }
-    
+
   return(out)
 
 }

--- a/R/run_cnmodel_f_bysite.R
+++ b/R/run_cnmodel_f_bysite.R
@@ -243,7 +243,8 @@ run_cnmodel_f_bysite <- function(
       dno3,
       dnh4,
       cseed,
-      nseed
+      nseed,
+      lai
       )
 
   # validate input
@@ -264,7 +265,8 @@ run_cnmodel_f_bysite <- function(
       "dno3",
       "dnh4",
       "cseed",
-      "nseed"
+      "nseed",
+      "lai"
     )
     
     # create a loop to loop over a list of variables

--- a/src/allocation_cnmodel.mod.f90
+++ b/src/allocation_cnmodel.mod.f90
@@ -48,6 +48,15 @@ module md_allocation_cnmodel
   type( params_allocation_type ) :: params_allocation
 
   real :: test
+  
+  !-------------------------------------------------------------------
+  ! MF: 2026-08-13
+  ! Maximum fraction of the current labile C and N pools that may be
+  ! used within one timestep to support additional leaf growth toward
+  ! prescribed LAI. A very small residual fraction is retained to avoid
+  ! complete depletion and numerical instability of the labile pools.
+  !-------------------------------------------------------------------
+  real, parameter :: frac_labile_for_prescr_lai = 0.999
 
 contains
 
@@ -68,6 +77,14 @@ contains
     ! local variables
     real :: dcleaf
     real :: dnleaf
+    real :: cleaf_target      ! MF: 2026-08-12
+    real :: nleaf_target      ! MF: 2026-08-12
+    real :: dcleaf_prescr     ! MF: 2026-08-12
+    real :: dnleaf_prescr     ! MF: 2026-08-12
+    real :: dcleaf_available  ! MF: 2026-08-13
+    real :: lai_trial         ! MF: 2026-08-13
+    real :: nleaf_trial       ! MF: 2026-08-13
+    integer :: nitr_prescr    ! MF: 2026-08-13
     real :: dcroot
     real :: dcwood 
     real :: dnwood
@@ -326,6 +343,139 @@ contains
           dnleaf = 0.0
           dnroot = 0.0
           drgrow = 0.0
+
+      end if
+
+      !-------------------------------------------------------------------
+      ! MF: 2026-08-12
+      ! Additional leaf allocation required to reach prescribed LAI
+      !-------------------------------------------------------------------
+      if ( tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) then
+
+        cleaf_target = get_leaf_c_from_lai( &
+          pft, &
+          climate%lai_prescr, &
+          tile(lu)%plant(pft)%actnv_unitfapar &
+          )
+
+        nleaf_target = get_leaf_n_canopy( &
+          pft, &
+          climate%lai_prescr, &
+          tile(lu)%plant(pft)%actnv_unitfapar &
+          )
+
+        if ( cleaf_target > tile(lu)%plant(pft)%pleaf%c%c12 + eps ) then
+
+          dcleaf_prescr = cleaf_target - tile(lu)%plant(pft)%pleaf%c%c12
+          dnleaf_prescr = nleaf_target - tile(lu)%plant(pft)%pleaf%n%n14
+
+          !-------------------------------------------------------------------
+          ! Diagnostic
+          !-------------------------------------------------------------------
+          if ( climate%lai_prescr - tile(lu)%plant(pft)%lai_ind > 0.1 ) then
+
+            print*, 'MF LAI increase diagnostic'
+            print*, '  target LAI       = ', climate%lai_prescr
+            print*, '  current LAI      = ', tile(lu)%plant(pft)%lai_ind
+            print*, '  current Cleaf    = ', tile(lu)%plant(pft)%pleaf%c%c12
+            print*, '  target Cleaf     = ', cleaf_target
+            print*, '  required dCleaf  = ', dcleaf_prescr
+            print*, '  available Clabl  = ', tile(lu)%plant(pft)%plabl%c%c12
+            print*, '  C incl. growth R = ', dcleaf_prescr / params_plant%growtheff
+            print*, '  current Nleaf    = ', tile(lu)%plant(pft)%pleaf%n%n14
+            print*, '  target Nleaf     = ', nleaf_target
+            print*, '  required dNleaf  = ', dnleaf_prescr
+            print*, '  available Nlabl  = ', tile(lu)%plant(pft)%plabl%n%n14
+
+          end if
+          
+          !-------------------------------------------------------------------
+          ! Maximum leaf-C increment affordable from labile C.
+          !-------------------------------------------------------------------
+          dcleaf_available = min( &
+            dcleaf_prescr, &
+            frac_labile_for_prescr_lai * &
+            tile(lu)%plant(pft)%plabl%c%c12 * params_plant%growtheff &
+            )
+
+          !-------------------------------------------------------------------
+          ! If N balance is closed, reduce the candidate leaf-C allocation
+          ! until the associated leaf-N requirement fits available labile N.
+          !-------------------------------------------------------------------
+          if ( dcleaf_available > eps ) then
+
+            nitr_prescr = 0
+
+            do
+
+              lai_trial = get_lai( &
+                pft, &
+                tile(lu)%plant(pft)%pleaf%c%c12 + dcleaf_available, &
+                tile(lu)%plant(pft)%actnv_unitfapar &
+                )
+
+              nleaf_trial = get_leaf_n_canopy( &
+                pft, &
+                lai_trial, &
+                tile(lu)%plant(pft)%actnv_unitfapar &
+                )
+
+              if ( &
+                nleaf_trial - tile(lu)%plant(pft)%pleaf%n%n14 <= &
+                frac_labile_for_prescr_lai * &
+                tile(lu)%plant(pft)%plabl%n%n14 + eps &
+                ) exit
+
+              dcleaf_available = 0.9 * dcleaf_available
+              nitr_prescr = nitr_prescr + 1
+
+              if ( dcleaf_available <= eps ) exit
+
+              if ( nitr_prescr >= 100 ) then
+                dcleaf_available = 0.0
+                exit
+              end if
+
+            end do
+
+          end if
+
+          if ( climate%lai_prescr - tile(lu)%plant(pft)%lai_ind > 0.1 ) then
+            print*, '  affordable dCleaf = ', dcleaf_available
+          end if
+
+          !-------------------------------------------------------------------
+          ! Allocate affordable amount toward prescribed LAI
+          !-------------------------------------------------------------------
+          if ( dcleaf_available > eps ) then
+
+            call allocate_leaf( &
+              pft, &
+              dcleaf_available, &
+              tile(lu)%plant(pft)%pleaf%c%c12, &
+              tile(lu)%plant(pft)%pleaf%n%n14, &
+              tile(lu)%plant(pft)%plabl%c%c12, &
+              tile(lu)%plant(pft)%plabl%n%n14, &
+              tile_fluxes(lu)%plant(pft)%drgrow, &
+              tile(lu)%plant(pft)%actnv_unitfapar, &
+              tile(lu)%plant(pft)%lai_ind, &
+              dnleaf_prescr, &
+              myinterface%steering%closed_nbal, &
+              tile_fluxes(lu)%plant(pft)%dnup_fix &
+              )
+
+            tile(lu)%plant(pft)%fapar_ind = get_fapar( &
+              tile(lu)%plant(pft)%lai_ind &
+              )
+
+            call update_leaftraits( tile(lu)%plant(pft) )
+
+            dcleaf = dcleaf + dcleaf_available
+            dnleaf = dnleaf + dnleaf_prescr
+
+          end if
+
+        end if
 
       end if
 

--- a/src/allocation_cnmodel.mod.f90
+++ b/src/allocation_cnmodel.mod.f90
@@ -11,7 +11,7 @@ module md_allocation_cnmodel
 
   implicit none
 
-  private 
+  private
   public allocation_daily, getpar_modl_allocation
 
   !----------------------------------------------------------------
@@ -48,7 +48,7 @@ module md_allocation_cnmodel
   type( params_allocation_type ) :: params_allocation
 
   real :: test
-  
+
   !-------------------------------------------------------------------
   ! MF: 2026-08-13
   ! Maximum fraction of the current labile C and N pools that may be
@@ -86,7 +86,7 @@ contains
     real :: nleaf_trial       ! MF: 2026-08-13
     integer :: nitr_prescr    ! MF: 2026-08-13
     real :: dcroot
-    real :: dcwood 
+    real :: dcwood
     real :: dnwood
     real :: dcseed
     real :: dnseed
@@ -106,7 +106,7 @@ contains
     integer :: idx
     integer :: usemoy        ! MOY in climate vectors to use for allocation
     integer :: usedoy        ! DOY in climate vectors to use for allocation
-  
+
     type(orgpool) :: avl
 
     integer, parameter :: len_resp_vec = 30
@@ -132,7 +132,7 @@ contains
     integer, parameter :: len_rrum_vec = ndayyear
     integer, parameter :: len_rduf_vec = ndayyear
     integer, parameter :: len_cn_vec   = ndayyear
-    
+
     real, dimension(nlu,npft,len_luep_vec), save :: luep_vec
     real, dimension(nlu,npft,len_rduf_vec), save :: rduf_vec
     real, dimension(nlu,npft,len_rrum_vec), save :: rrum_vec
@@ -223,7 +223,7 @@ contains
 
           ! print*,'dcleaf, dcroot ', dcleaf, dcroot
 
-          tile_fluxes(lu)%plant(pft)%debug4 = tile(lu)%plant(pft)%pheno%level_veggrowth 
+          tile_fluxes(lu)%plant(pft)%debug4 = tile(lu)%plant(pft)%pheno%level_veggrowth
 
           !-------------------------------------------------------------------
           ! SEED ALLOCATION
@@ -232,7 +232,7 @@ contains
                       tile(lu)%plant(pft)%plabl, &
                       tile(lu)%plant(pft)%pseed &
                       )
-          
+
           ! ... and remove growth respiration from labile C, update growth respiration
           dclabl = (1.0 / params_plant%growtheff) * dcseed
           tile(lu)%plant(pft)%plabl%c%c12 = tile(lu)%plant(pft)%plabl%c%c12 - dclabl
@@ -278,15 +278,15 @@ contains
               tile_fluxes(lu)%plant(pft)%dnup_fix &
               )
 
-            !-------------------------------------------------------------------  
+            !-------------------------------------------------------------------
             ! Update leaf traits, given updated LAI and fAPAR (leaf N is consistent with plant%narea_canopy)
-            !------------------------------------------------------------------- 
+            !-------------------------------------------------------------------
             tile(lu)%plant(pft)%fapar_ind = get_fapar( tile(lu)%plant(pft)%lai_ind )
             call update_leaftraits( tile(lu)%plant(pft) )
 
-            !-------------------------------------------------------------------  
+            !-------------------------------------------------------------------
             ! If labile N gets negative, account gap as N fixation
-            !-------------------------------------------------------------------  
+            !-------------------------------------------------------------------
             if ( tile(lu)%plant(pft)%plabl%n%n14 < 0.0 ) then
               ! stop 'labile N got negative'
               req = 2.0 * abs(tile(lu)%plant(pft)%plabl%n%n14) ! give it a bit more (factor 2)
@@ -315,9 +315,9 @@ contains
               tile_fluxes(lu)%plant(pft)%dnup_fix &
               )
 
-            !-------------------------------------------------------------------  
+            !-------------------------------------------------------------------
             ! If labile N gets negative, account gap as N fixation
-            !-------------------------------------------------------------------  
+            !-------------------------------------------------------------------
             if ( tile(lu)%plant(pft)%plabl%n%n14 < 0.0 ) then
               ! stop 'labile N got negative'
               req = 2.0 * abs(tile(lu)%plant(pft)%plabl%n%n14) ! give it a bit more (factor 2)
@@ -350,134 +350,114 @@ contains
       ! MF: 2026-08-12
       ! Additional leaf allocation required to reach prescribed LAI
       !-------------------------------------------------------------------
-      if ( tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) then
+      if ( myinterface%params_siml%use_prescribed_lai ) then
 
-        cleaf_target = get_leaf_c_from_lai( &
-          pft, &
-          climate%lai_prescr, &
-          tile(lu)%plant(pft)%actnv_unitfapar &
-          )
+        if ( tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) then
 
-        nleaf_target = get_leaf_n_canopy( &
-          pft, &
-          climate%lai_prescr, &
-          tile(lu)%plant(pft)%actnv_unitfapar &
-          )
-
-        if ( cleaf_target > tile(lu)%plant(pft)%pleaf%c%c12 + eps ) then
-
-          dcleaf_prescr = cleaf_target - tile(lu)%plant(pft)%pleaf%c%c12
-          dnleaf_prescr = nleaf_target - tile(lu)%plant(pft)%pleaf%n%n14
-
-          !-------------------------------------------------------------------
-          ! Diagnostic
-          !-------------------------------------------------------------------
-          if ( climate%lai_prescr - tile(lu)%plant(pft)%lai_ind > 0.1 ) then
-
-            print*, 'MF LAI increase diagnostic'
-            print*, '  target LAI       = ', climate%lai_prescr
-            print*, '  current LAI      = ', tile(lu)%plant(pft)%lai_ind
-            print*, '  current Cleaf    = ', tile(lu)%plant(pft)%pleaf%c%c12
-            print*, '  target Cleaf     = ', cleaf_target
-            print*, '  required dCleaf  = ', dcleaf_prescr
-            print*, '  available Clabl  = ', tile(lu)%plant(pft)%plabl%c%c12
-            print*, '  C incl. growth R = ', dcleaf_prescr / params_plant%growtheff
-            print*, '  current Nleaf    = ', tile(lu)%plant(pft)%pleaf%n%n14
-            print*, '  target Nleaf     = ', nleaf_target
-            print*, '  required dNleaf  = ', dnleaf_prescr
-            print*, '  available Nlabl  = ', tile(lu)%plant(pft)%plabl%n%n14
-
-          end if
-          
-          !-------------------------------------------------------------------
-          ! Maximum leaf-C increment affordable from labile C.
-          !-------------------------------------------------------------------
-          dcleaf_available = min( &
-            dcleaf_prescr, &
-            frac_labile_for_prescr_lai * &
-            tile(lu)%plant(pft)%plabl%c%c12 * params_plant%growtheff &
+          cleaf_target = get_leaf_c_from_lai( &
+            pft, &
+            climate%lai_prescr, &
+            tile(lu)%plant(pft)%actnv_unitfapar &
             )
 
-          !-------------------------------------------------------------------
-          ! If N balance is closed, reduce the candidate leaf-C allocation
-          ! until the associated leaf-N requirement fits available labile N.
-          !-------------------------------------------------------------------
-          if ( dcleaf_available > eps ) then
+          nleaf_target = get_leaf_n_canopy( &
+            pft, &
+            climate%lai_prescr, &
+            tile(lu)%plant(pft)%actnv_unitfapar &
+            )
 
-            nitr_prescr = 0
+          if ( cleaf_target > tile(lu)%plant(pft)%pleaf%c%c12 + eps ) then
 
-            do
+            dcleaf_prescr = cleaf_target - tile(lu)%plant(pft)%pleaf%c%c12
+            dnleaf_prescr = nleaf_target - tile(lu)%plant(pft)%pleaf%n%n14
 
-              lai_trial = get_lai( &
-                pft, &
-                tile(lu)%plant(pft)%pleaf%c%c12 + dcleaf_available, &
-                tile(lu)%plant(pft)%actnv_unitfapar &
-                )
-
-              nleaf_trial = get_leaf_n_canopy( &
-                pft, &
-                lai_trial, &
-                tile(lu)%plant(pft)%actnv_unitfapar &
-                )
-
-              if ( &
-                nleaf_trial - tile(lu)%plant(pft)%pleaf%n%n14 <= &
-                frac_labile_for_prescr_lai * &
-                tile(lu)%plant(pft)%plabl%n%n14 + eps &
-                ) exit
-
-              dcleaf_available = 0.9 * dcleaf_available
-              nitr_prescr = nitr_prescr + 1
-
-              if ( dcleaf_available <= eps ) exit
-
-              if ( nitr_prescr >= 100 ) then
-                dcleaf_available = 0.0
-                exit
-              end if
-
-            end do
-
-          end if
-
-          if ( climate%lai_prescr - tile(lu)%plant(pft)%lai_ind > 0.1 ) then
-            print*, '  affordable dCleaf = ', dcleaf_available
-          end if
-
-          !-------------------------------------------------------------------
-          ! Allocate affordable amount toward prescribed LAI
-          !-------------------------------------------------------------------
-          if ( dcleaf_available > eps ) then
-
-            call allocate_leaf( &
-              pft, &
-              dcleaf_available, &
-              tile(lu)%plant(pft)%pleaf%c%c12, &
-              tile(lu)%plant(pft)%pleaf%n%n14, &
-              tile(lu)%plant(pft)%plabl%c%c12, &
-              tile(lu)%plant(pft)%plabl%n%n14, &
-              tile_fluxes(lu)%plant(pft)%drgrow, &
-              tile(lu)%plant(pft)%actnv_unitfapar, &
-              tile(lu)%plant(pft)%lai_ind, &
-              dnleaf_prescr, &
-              myinterface%steering%closed_nbal, &
-              tile_fluxes(lu)%plant(pft)%dnup_fix &
+            !-------------------------------------------------------------------
+            ! Maximum leaf-C increment affordable from labile C.
+            !-------------------------------------------------------------------
+            dcleaf_available = min( &
+              dcleaf_prescr, &
+              frac_labile_for_prescr_lai * &
+              tile(lu)%plant(pft)%plabl%c%c12 * params_plant%growtheff &
               )
 
-            tile(lu)%plant(pft)%fapar_ind = get_fapar( &
-              tile(lu)%plant(pft)%lai_ind &
-              )
+            !-------------------------------------------------------------------
+            ! If N balance is closed, reduce the candidate leaf-C allocation
+            ! until the associated leaf-N requirement fits available labile N.
+            !-------------------------------------------------------------------
+            if ( dcleaf_available > eps ) then
 
-            call update_leaftraits( tile(lu)%plant(pft) )
+              nitr_prescr = 0
 
-            dcleaf = dcleaf + dcleaf_available
-            dnleaf = dnleaf + dnleaf_prescr
+              do
 
-          end if
+                lai_trial = get_lai( &
+                  pft, &
+                  tile(lu)%plant(pft)%pleaf%c%c12 + dcleaf_available, &
+                  tile(lu)%plant(pft)%actnv_unitfapar &
+                  )
 
-        end if
+                nleaf_trial = get_leaf_n_canopy( &
+                  pft, &
+                  lai_trial, &
+                  tile(lu)%plant(pft)%actnv_unitfapar &
+                  )
 
-      end if
+                if ( &
+                  nleaf_trial - tile(lu)%plant(pft)%pleaf%n%n14 <= &
+                  frac_labile_for_prescr_lai * &
+                  tile(lu)%plant(pft)%plabl%n%n14 + eps &
+                  ) exit
+
+                dcleaf_available = 0.9 * dcleaf_available
+                nitr_prescr = nitr_prescr + 1
+
+                if ( dcleaf_available <= eps ) exit
+
+                if ( nitr_prescr >= 100 ) then
+                  dcleaf_available = 0.0
+                  exit
+                end if
+
+              end do
+
+            end if
+
+            !-------------------------------------------------------------------
+            ! Allocate affordable amount toward prescribed LAI
+            !-------------------------------------------------------------------
+            if ( dcleaf_available > eps ) then
+
+              call allocate_leaf( &
+                pft, &
+                dcleaf_available, &
+                tile(lu)%plant(pft)%pleaf%c%c12, &
+                tile(lu)%plant(pft)%pleaf%n%n14, &
+                tile(lu)%plant(pft)%plabl%c%c12, &
+                tile(lu)%plant(pft)%plabl%n%n14, &
+                tile_fluxes(lu)%plant(pft)%drgrow, &
+                tile(lu)%plant(pft)%actnv_unitfapar, &
+                tile(lu)%plant(pft)%lai_ind, &
+                dnleaf_prescr, &
+                myinterface%steering%closed_nbal, &
+                tile_fluxes(lu)%plant(pft)%dnup_fix &
+                )
+
+              tile(lu)%plant(pft)%fapar_ind = get_fapar( &
+                tile(lu)%plant(pft)%lai_ind &
+                )
+
+              call update_leaftraits( tile(lu)%plant(pft) )
+
+              dcleaf = dcleaf + dcleaf_available
+              dnleaf = dnleaf + dnleaf_prescr
+
+            end if  ! dcleaf_available > eps
+
+          end if    ! cleaf_target > current Cleaf
+
+        end if      ! pleaf > 0
+
+      end if        ! use_prescribed_lai
 
       !-------------------------------------------------------------------
       ! Record acquired and required C and N
@@ -520,7 +500,7 @@ contains
       end if
 
 
-      ! return on leaf investment, defined as sum of C assimilated (after leaf dark respiration, but before exudation, root and other respiration) 
+      ! return on leaf investment, defined as sum of C assimilated (after leaf dark respiration, but before exudation, root and other respiration)
       ! divided by sum over C invested into leaf construction (ignoring growth respiration)
       psi_c = sum( g_net_vec(lu,pft,:) ) / sum( c_a_l_vec(lu,pft,:) )
 
@@ -588,7 +568,7 @@ contains
       ! if (.not. myinterface%steering%spinup_reserves) then
       !   tile(lu)%plant(pft)%presv%c%c12 = c_resv_target
       !   if (pft == npft .and. lu == nlu) firstcall_resv = .false.
-      ! end if      
+      ! end if
 
       ! net C flux from reserves to labile pool
       f_resv_to_labl = calc_f_reserves_labile(&
@@ -614,7 +594,7 @@ contains
           tile(lu)%plant(pft)%presv%c%c12 = tile(lu)%plant(pft)%presv%c%c12 - org_resv_to_labl%c%c12
           tile(lu)%plant(pft)%presv%n%n14 = tile(lu)%plant(pft)%presv%n%n14 - org_resv_to_labl%n%n14
         end if
-        
+
       else if (c_resv_target > 0.0) then
 
         ! transfer C and N to reserves, source pool is plabl
@@ -667,7 +647,7 @@ contains
     ! Sequence of steps:
     ! - increment foliage C pool
     ! - update LAI
-    ! - calculate canopy-level foliage N as a function of LAI 
+    ! - calculate canopy-level foliage N as a function of LAI
     ! - reduce labile pool by C and N increments
     !-------------------------------------------------------------------
     ! arguments
@@ -739,7 +719,7 @@ contains
         nfix = nfix - nlabl
         nlabl = 0.0
       end if
-    end if  
+    end if
 
   end subroutine allocate_leaf
 
@@ -863,8 +843,8 @@ contains
 
   function calc_ft_growth( xx ) result( yy )
     !////////////////////////////////////////////////////////////////
-    ! Temperature limitation function to growth. Increases from around 
-    ! 0 at 0 deg C to 1 at around 10 deg C. The factor scales the 
+    ! Temperature limitation function to growth. Increases from around
+    ! 0 at 0 deg C to 1 at around 10 deg C. The factor scales the
     ! amount of C that becomes available for growth.
     !----------------------------------------------------------------
     ! arguments
@@ -884,7 +864,7 @@ contains
   function calc_l2r(c_labl, c_resv, c_labl_target, c_resv_target, f_max) result( out )
     !///////////////////////////////////////////////////////////
     ! Function for trickling from labile to reserves
-    ! Returns the fraction of the labile pool (is source pool) 
+    ! Returns the fraction of the labile pool (is source pool)
     ! moving from labile to reserves.
     !-----------------------------------------------------------
     real, intent(in) :: c_labl, c_resv, c_labl_target, c_resv_target, f_max
@@ -940,7 +920,7 @@ contains
 
   ! function get_rcton_init( pft, meanmppfd, nv ) result( rcton )
   !   !////////////////////////////////////////////////////////////////
-  !   ! Calculates initial guess based on Taylor approximation of 
+  !   ! Calculates initial guess based on Taylor approximation of
   !   ! Cleaf and Nleaf function around cleaf=0.
   !   ! Cleaf = c_molmass * params_pft_plant(pft)%r_ctostructn_leaf * [ meanmppfd * (1-exp(-kbeer*LAI)) * nv * params_pft_plant(pft)%r_n_cw_v + LAI * params_pft_plant(pft)%ncw_min ]
   !   ! Nleaf = n_molmass * [ meanmppfd * (1-exp(-kbeer*LAI)) * nv * (params_pft_plant(pft)%r_n_cw_v + 1) + LAI * params_pft_plant(pft)%ncw_min ]
@@ -963,10 +943,10 @@ contains
   !   real :: maxnv
   !   real :: tmp1, tmp2, tmp3
 
-  !   ! Metabolic N is predicted and is optimised at a monthly time scale. 
+  !   ! Metabolic N is predicted and is optimised at a monthly time scale.
   !   ! Leaf traits are calculated based on metabolic N => cellwall N => cellwall C / LMA
   !   ! Leaves get thinner at the bottom of the canopy => increasing LAI through the season comes at a declining C and N cost
-  !   ! Monthly variations in metabolic N, determined by variations in meanmppfd and nv should not result in variations in leaf traits. 
+  !   ! Monthly variations in metabolic N, determined by variations in meanmppfd and nv should not result in variations in leaf traits.
   !   ! In order to prevent this, assume annual maximum metabolic N, part of which is deactivated during months with lower insolation (and Rd reduced.)
   !   maxnv = maxval( meanmppfd(:) * nv(:) )
 

--- a/src/biosphere_cnmodel.mod.f90
+++ b/src/biosphere_cnmodel.mod.f90
@@ -193,6 +193,9 @@ contains
         if (verbose) print*, '... done'
 
         ! print*,'c presv: ', tile(1)%plant(1)%presv
+        
+        ! MF: 20260811
+        tile(1)%canopy%fapar = myinterface%climate(doy)%fapar_prescr
 
         !----------------------------------------------------------------
         ! calculate GPP

--- a/src/biosphere_cnmodel.mod.f90
+++ b/src/biosphere_cnmodel.mod.f90
@@ -194,8 +194,10 @@ contains
 
         ! print*,'c presv: ', tile(1)%plant(1)%presv
         
-        ! MF: 20260811
-        tile(1)%canopy%fapar = myinterface%climate(doy)%fapar_prescr
+        ! MF: configurable prescribed fAPAR
+        if ( myinterface%params_siml%use_prescribed_fapar ) then
+          tile(1)%canopy%fapar = myinterface%climate(doy)%fapar_prescr
+        end if
 
         !----------------------------------------------------------------
         ! calculate GPP

--- a/src/forcing_siterun_cnmodel.mod.f90
+++ b/src/forcing_siterun_cnmodel.mod.f90
@@ -26,6 +26,7 @@ module md_forcing_cnmodel
     real(kind=sp) :: dnetrad! W m-2
     real(kind=sp) :: dpatm  ! Pa
     real(kind=sp) :: fapar_prescr ! unitless, fAPAR from forcing
+    real(kind=sp) :: lai_prescr ! m2 leaf m-2 ground, LAI from forcing
   end type climate_type
 
   type vegcover_type
@@ -51,7 +52,7 @@ contains
     !----------------------------------------------------------------
     ! arguments
     integer,  intent(in) :: nt ! number of time steps
-    real(kind=dp),  dimension(nt,17), intent(in)  :: forcing  ! array containing all temporally varying forcing data
+    real(kind=dp),  dimension(nt,18), intent(in)  :: forcing  ! array containing all temporally varying forcing data
     integer, intent(in) :: climateyear_idx
     logical, intent(in) :: in_ppfd
     logical, intent(in) :: in_netrad
@@ -100,6 +101,9 @@ contains
 
     ! xxx milan: take fAPAR from forcing
     out_climate(:)%fapar_prescr = real(forcing(idx_start:idx_end, 9))
+    
+    ! MF: prescribed LAI from forcing
+    out_climate(:)%lai_prescr = real(forcing(idx_start:idx_end, 18))
 
   end function getclimate
   
@@ -110,7 +114,7 @@ contains
     !----------------------------------------------------------------
     ! arguments
     integer,  intent(in) :: nt ! number of time steps
-    real(kind=dp),  dimension(nt,17), intent(in)  :: forcing  ! array containing all temporally varying forcing data
+    real(kind=dp),  dimension(nt,18), intent(in)  :: forcing  ! array containing all temporally varying forcing data
     integer, intent(in) :: forcingyear
     integer, intent(in) :: firstyeartrend
 
@@ -137,7 +141,7 @@ contains
     !----------------------------------------------------------------
     ! arguments
     integer,  intent(in) :: nt ! number of time steps
-    real(kind=dp), dimension(nt,17), intent(in)  :: forcing  ! array containing all temporally varying forcing data
+    real(kind=dp), dimension(nt,18), intent(in)  :: forcing  ! array containing all temporally varying forcing data
     integer, intent(in) :: forcingyear_idx
 
     ! function return variable
@@ -218,7 +222,7 @@ contains
     !----------------------------------------------------------------
     ! arguments
     integer,  intent(in) :: nt ! number of time steps
-    real(kind=dp),  dimension(nt,17), intent(in)  :: forcing  ! array containing all temporally varying forcing data
+    real(kind=dp),  dimension(nt,18), intent(in)  :: forcing  ! array containing all temporally varying forcing data
     integer, intent(in) :: forcingyear
     integer, intent(in) :: firstyeartrend
 

--- a/src/main_cnmodel.mod.f90
+++ b/src/main_cnmodel.mod.f90
@@ -71,7 +71,7 @@ contains
     real(kind=c_double),  intent(in) :: whc
     integer(kind=c_int),  intent(in) :: nt ! number of time steps
     real(kind=c_double),  dimension(86), intent(in) :: par  ! Model parameters
-    real(kind=c_double),  dimension(nt,17), intent(in) :: forcing  ! temp = 1, rain = 2, vpd = 3, ppfd = 4, netrad = 5, fsun = 6, snow = 7, co2 = 8, fapar = 9, patm = 10, tmin = 11, tmax = 12, fharv = 13, dno3 = 14, dnh4 = 15, cseed = 16, nseed = 17
+    real(kind=c_double),  dimension(nt,18), intent(in) :: forcing  ! temp = 1, rain = 2, vpd = 3, ppfd = 4, netrad = 5, fsun = 6, snow = 7, co2 = 8, fapar = 9, patm = 10, tmin = 11, tmax = 12, fharv = 13, dno3 = 14, dnh4 = 15, cseed = 16, nseed = 17, lai = 18
     real(kind=c_double),  dimension(nt,70), intent(out) :: output
 
     ! local variables

--- a/src/main_cnmodel.mod.f90
+++ b/src/main_cnmodel.mod.f90
@@ -13,25 +13,27 @@ contains
   !----------------------------------------------------------------
   subroutine cnmodel_f(        &
     c_only,                    &
-    spinup,                    &   
-    spinupyears,               &        
-    recycle,                   &    
-    firstyeartrend,            &           
-    nyeartrend,                &  
-    secs_per_tstep,            &     
-    in_ppfd,                   &    
-    in_netrad,                 &      
-    outdt,                     &  
-    ltre,                      & 
-    ltne,                      & 
-    ltrd,                      & 
-    ltnd,                      & 
-    lgr3,                      & 
-    lgn3,                      & 
-    lgr4,                      & 
-    longitude,                 &      
-    latitude,                  &     
-    altitude,                  &   
+    spinup,                    &
+    spinupyears,               &
+    recycle,                   &
+    firstyeartrend,            &
+    nyeartrend,                &
+    secs_per_tstep,            &
+    in_ppfd,                   &
+    in_netrad,                 &
+    use_prescribed_fapar,      &
+    use_prescribed_lai,        &
+    outdt,                     &
+    ltre,                      &
+    ltne,                      &
+    ltrd,                      &
+    ltnd,                      &
+    lgr3,                      &
+    lgn3,                      &
+    lgr4,                      &
+    longitude,                 &
+    latitude,                  &
+    altitude,                  &
     whc,                       &
     nt,                        &
     par,                       &
@@ -57,6 +59,8 @@ contains
     integer(kind=c_int),  intent(in) :: secs_per_tstep
     logical(kind=c_bool), intent(in) :: in_ppfd
     logical(kind=c_bool), intent(in) :: in_netrad
+    logical(kind=c_bool), intent(in) :: use_prescribed_fapar
+    logical(kind=c_bool), intent(in) :: use_prescribed_lai
     integer(kind=c_int),  intent(in) :: outdt
     logical(kind=c_bool), intent(in) :: ltre
     logical(kind=c_bool), intent(in) :: ltne
@@ -94,18 +98,20 @@ contains
       myinterface%params_siml%runyears = myinterface%params_siml%nyeartrend
       myinterface%params_siml%spinupyears = 0
     endif
-    
-    myinterface%params_siml%in_ppfd            = in_ppfd
-    myinterface%params_siml%in_netrad          = in_netrad
-    myinterface%params_siml%outdt              = outdt
-    myinterface%params_siml%ltre               = ltre
-    myinterface%params_siml%ltne               = ltne
-    myinterface%params_siml%ltrd               = ltrd
-    myinterface%params_siml%ltnd               = ltnd
-    myinterface%params_siml%lgr3               = lgr3
-    myinterface%params_siml%lgn3               = lgn3
-    myinterface%params_siml%lgr4               = lgr4
-    myinterface%params_siml%secs_per_tstep     = secs_per_tstep
+
+    myinterface%params_siml%in_ppfd              = in_ppfd
+    myinterface%params_siml%in_netrad            = in_netrad
+    myinterface%params_siml%use_prescribed_fapar = use_prescribed_fapar
+    myinterface%params_siml%use_prescribed_lai   = use_prescribed_lai
+    myinterface%params_siml%outdt                = outdt
+    myinterface%params_siml%ltre                 = ltre
+    myinterface%params_siml%ltne                 = ltne
+    myinterface%params_siml%ltrd                 = ltrd
+    myinterface%params_siml%ltnd                 = ltnd
+    myinterface%params_siml%lgr3                 = lgr3
+    myinterface%params_siml%lgn3                 = lgn3
+    myinterface%params_siml%lgr4                 = lgr4
+    myinterface%params_siml%secs_per_tstep       = secs_per_tstep
 
     ! Count PFTs to be simulated
     npft_local = 0
@@ -131,7 +137,7 @@ contains
     ! GET SOIL PARAMETERS
     !----------------------------------------------------------------
     myinterface%whc_prescr = real( whc )
-    
+
     !----------------------------------------------------------------
     ! GET CALIBRATABLE MODEL PARAMETERS
     ! (not necessarily all to actually be calibrated)
@@ -228,7 +234,7 @@ contains
     ! GET VEGETATION COVER (fractional projective cover by PFT)
     !----------------------------------------------------------------
     myinterface%fpc_grid(:) = get_fpc_grid( myinterface%params_siml )
-    
+
     yearloop: do yr=1,myinterface%params_siml%runyears
 
       !----------------------------------------------------------------
@@ -265,7 +271,7 @@ contains
       !----------------------------------------------------------------
       ! Call biosphere (wrapper for all modules, contains gridcell loop)
       !----------------------------------------------------------------
-      out_biosphere = biosphere_annual() 
+      out_biosphere = biosphere_annual()
       !----------------------------------------------------------------
 
       !----------------------------------------------------------------
@@ -276,14 +282,14 @@ contains
         idx_start = (myinterface%steering%forcingyear_idx - 1) * ndayyear + 1
         idx_end   = idx_start + ndayyear - 1
 
-        output(idx_start:idx_end,1)  = dble(out_biosphere(:)%fapar)  
-        output(idx_start:idx_end,2)  = dble(out_biosphere(:)%gpp)    
-        output(idx_start:idx_end,3)  = dble(out_biosphere(:)%transp) 
+        output(idx_start:idx_end,1)  = dble(out_biosphere(:)%fapar)
+        output(idx_start:idx_end,2)  = dble(out_biosphere(:)%gpp)
+        output(idx_start:idx_end,3)  = dble(out_biosphere(:)%transp)
         output(idx_start:idx_end,4)  = dble(out_biosphere(:)%latenth)
         output(idx_start:idx_end,5)  = dble(out_biosphere(:)%pet)
-        output(idx_start:idx_end,6)  = dble(out_biosphere(:)%vcmax)  
-        output(idx_start:idx_end,7)  = dble(out_biosphere(:)%jmax)    
-        output(idx_start:idx_end,8)  = dble(out_biosphere(:)%vcmax25) 
+        output(idx_start:idx_end,6)  = dble(out_biosphere(:)%vcmax)
+        output(idx_start:idx_end,7)  = dble(out_biosphere(:)%jmax)
+        output(idx_start:idx_end,8)  = dble(out_biosphere(:)%vcmax25)
         output(idx_start:idx_end,9)  = dble(out_biosphere(:)%jmax25)
         output(idx_start:idx_end,10) = dble(out_biosphere(:)%gs_accl)
         output(idx_start:idx_end,11) = dble(out_biosphere(:)%wscal)

--- a/src/params_siml_cnmodel.mod.f90
+++ b/src/params_siml_cnmodel.mod.f90
@@ -30,7 +30,9 @@ module md_params_siml_cnmodel
 
     ! optionally prescribed variables (if false, then simulated internally)
     logical :: in_netrad    ! net radiation
-    logical :: in_ppfd      ! photosynthetic photon flux density 
+    logical :: in_ppfd      ! photosynthetic photon flux density
+    logical :: use_prescribed_fapar   ! use externally prescribed fAPAR
+    logical :: use_prescribed_lai     ! use externally prescribed LAI
 
     ! activated PFTs
     logical :: ltre        ! evergreen tree

--- a/src/plant_cnmodel.mod.f90
+++ b/src/plant_cnmodel.mod.f90
@@ -13,7 +13,8 @@ module md_plant_cnmodel
   public plant_type, plant_fluxes_type, getpar_modl_plant, &
     init_plant, params_plant, params_pft_plant, ftemp, &
     fmoist, add_seed, update_leaftraits, get_leaftraits_init, &
-    get_lai, get_fapar, init_plant_fluxes, get_leaf_n_canopy, &
+    get_lai, get_fapar, get_leaf_c_from_lai, init_plant_fluxes, &
+    get_leaf_n_canopy, &
 
     ! debug
     r_cton_leaf, r_ntoc_leaf
@@ -236,6 +237,50 @@ contains
     fapar = ( 1.0 - exp( -1.0 * params_plant%kbeer * lai) )
 
   end function get_fapar
+  
+  
+  ! MF: 2026-08-12
+  function get_leaf_c_from_lai( pft, lai, actnv_unitfapar ) result( cleaf )
+    !////////////////////////////////////////////////////////////////
+    ! Calculates canopy leaf C corresponding to a prescribed LAI,
+    ! using the same leaf-trait relationships as the CN model.
+    !----------------------------------------------------------------
+    use md_params_core, only: c_molmass
+    
+    ! arguments
+    integer, intent(in) :: pft
+    real, intent(in)    :: lai
+    real, intent(in)    :: actnv_unitfapar
+    
+    ! function return variable
+    real :: cleaf
+    
+    ! local variables
+    real :: fapar
+    real :: nleaf_metabolic
+    real :: nleaf_structural
+    
+    if (lai > 0.0) then
+    
+      fapar = get_fapar( lai )
+    
+      nleaf_metabolic = get_leaf_n_metabolic_canopy( &
+        fapar, actnv_unitfapar )
+    
+      nleaf_structural = get_leaf_n_structural_canopy( &
+        pft, lai, nleaf_metabolic )
+    
+      cleaf = c_molmass * &
+        params_pft_plant(pft)%r_ctostructn_leaf * &
+        nleaf_structural
+    
+    else
+    
+      cleaf = 0.0
+    
+    end if
+    
+  end function get_leaf_c_from_lai
 
 
   function get_lai( pft, cleaf, actnv_unitfapar ) result( lai )

--- a/src/turnover.mod.f90
+++ b/src/turnover.mod.f90
@@ -6,6 +6,7 @@ module md_turnover
   use md_params_core, only: nlu, npft, eps, nmonth, ndayyear
   use md_tile_cnmodel
   use md_plant_cnmodel
+  use md_interface_cnmodel, only: myinterface ! MF: 2026-08-12
 
   implicit none
 
@@ -34,6 +35,8 @@ contains
     integer :: pft
     integer :: lu
     real :: dlabl, dleaf, droot, dseed, dwood
+    real :: cleaf_target ! MF: 2026-08-12
+    real :: dleaf_prescr ! MF: 2026-08-12
 
     real, parameter :: k_decay_wood = 1.0 / 100.0
 
@@ -78,6 +81,30 @@ contains
       if (verbose) nbal1 = tile(lu)%plant(pft)%plabl%n%n14 + tile(lu)%plant(pft)%pleaf%n%n14 + tile(lu)%soil%plitt_af%n%n14
       !--------------------------------------------------------------
       if ( dleaf > 0.0 .and. tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) call turnover_leaf( dleaf, tile(lu), tile_fluxes(lu), pft )
+      ! MF: 2026-08-12
+      ! Additional leaf turnover required to reach prescribed LAI
+      if ( tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) then
+      
+        cleaf_target = get_leaf_c_from_lai( &
+          pft, &
+          myinterface%climate(doy)%lai_prescr, &
+          tile(lu)%plant(pft)%actnv_unitfapar &
+          )
+      
+        if ( cleaf_target < tile(lu)%plant(pft)%pleaf%c%c12 - eps ) then
+      
+          dleaf_prescr = 1.0 - cleaf_target / tile(lu)%plant(pft)%pleaf%c%c12
+      
+          call turnover_leaf( &
+            dleaf_prescr, &
+            tile(lu), &
+            tile_fluxes(lu), &
+            pft &
+            )
+      
+        end if
+      
+      end if      
       !--------------------------------------------------------------
       if (verbose) print*, '              ==> returned: '
       if (verbose) print*, '              pleaf = ', tile(lu)%plant(pft)%pleaf

--- a/src/turnover.mod.f90
+++ b/src/turnover.mod.f90
@@ -71,7 +71,7 @@ contains
       endif
 
       !--------------------------------------------------------------
-      ! Calculate leaf turnover in this day 
+      ! Calculate leaf turnover in this day
       !--------------------------------------------------------------
       if (verbose) print*, 'calling turnover_leaf() ... '
       if (verbose) print*, '              with state variables:'
@@ -83,28 +83,33 @@ contains
       if ( dleaf > 0.0 .and. tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) call turnover_leaf( dleaf, tile(lu), tile_fluxes(lu), pft )
       ! MF: 2026-08-12
       ! Additional leaf turnover required to reach prescribed LAI
-      if ( tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) then
-      
-        cleaf_target = get_leaf_c_from_lai( &
-          pft, &
-          myinterface%climate(doy)%lai_prescr, &
-          tile(lu)%plant(pft)%actnv_unitfapar &
-          )
-      
-        if ( cleaf_target < tile(lu)%plant(pft)%pleaf%c%c12 - eps ) then
-      
-          dleaf_prescr = 1.0 - cleaf_target / tile(lu)%plant(pft)%pleaf%c%c12
-      
-          call turnover_leaf( &
-            dleaf_prescr, &
-            tile(lu), &
-            tile_fluxes(lu), &
-            pft &
+      if ( myinterface%params_siml%use_prescribed_lai ) then
+
+
+        if ( tile(lu)%plant(pft)%pleaf%c%c12 > 0.0 ) then
+
+          cleaf_target = get_leaf_c_from_lai( &
+            pft, &
+            myinterface%climate(doy)%lai_prescr, &
+            tile(lu)%plant(pft)%actnv_unitfapar &
             )
-      
+
+          if ( cleaf_target < tile(lu)%plant(pft)%pleaf%c%c12 - eps ) then
+
+            dleaf_prescr = 1.0 - cleaf_target / tile(lu)%plant(pft)%pleaf%c%c12
+
+            call turnover_leaf( &
+              dleaf_prescr, &
+              tile(lu), &
+              tile_fluxes(lu), &
+              pft &
+              )
+
+          end if
+
         end if
-      
-      end if      
+
+      end if
       !--------------------------------------------------------------
       if (verbose) print*, '              ==> returned: '
       if (verbose) print*, '              pleaf = ', tile(lu)%plant(pft)%pleaf
@@ -120,7 +125,7 @@ contains
       if (baltest .and. abs(nbal1) > eps) stop 'balance 1 not satisfied'
 
       !--------------------------------------------------------------
-      ! Calculate root turnover in this day 
+      ! Calculate root turnover in this day
       !--------------------------------------------------------------
       if (verbose) print*, 'calling turnover_root() ... '
       if (verbose) print*, '              with state variables:'
@@ -145,7 +150,7 @@ contains
       if (baltest .and. abs(nbal1) > eps) stop 'balance 1 not satisfied'
 
       !--------------------------------------------------------------
-      ! Calculate wood turnover in this day 
+      ! Calculate wood turnover in this day
       !--------------------------------------------------------------
       if (verbose) print*, 'calling turnover_wood() ... '
       if (verbose) print*, '              with state variables:'
@@ -170,7 +175,7 @@ contains
       if (baltest .and. abs(nbal1) > eps) stop 'balance 1 not satisfied'
 
       !--------------------------------------------------------------
-      ! Calculate seed turnover in this day 
+      ! Calculate seed turnover in this day
       !--------------------------------------------------------------
       if (verbose) print*, 'calling turnover_seed() ... '
       if (verbose) print*, '              with state variables:'
@@ -219,7 +224,7 @@ contains
       if (verbose) print*, '                  d(nlitt + nroot)             = ', nbal1
       if (baltest .and. abs(cbal1) > eps) stop 'balance 1 not satisfied'
       if (baltest .and. abs(nbal1) > eps) stop 'balance 1 not satisfied'
-    
+
     enddo pftloop
 
   end subroutine turnover
@@ -317,7 +322,7 @@ contains
     if (verbose .and. nitr > 0) print*,'                      final reduction of leaf C ', cleaf / lm_init%c%c12
     if (verbose .and. nitr > 0) print*,'                      final reduction of leaf N ', nleaf / lm_init%n%n14
 
-    ! update 
+    ! update
     tile%plant(pft)%pleaf%c%c12 = cleaf
     tile%plant(pft)%pleaf%n%n14 = nleaf
 
@@ -463,7 +468,7 @@ contains
     ! reduce labile mass
     call orgsub( lb_turn, tile%plant(pft)%plabl )
 
-    ! call orgmvRec( lb_turn, lb_turn, tile%plant(pft)%plitt_af, outaCveg2lit(pft,jpngr), outaNveg2lit(pft,jpngr), scale = real(tile%plant(pft)%nind) 
+    ! call orgmvRec( lb_turn, lb_turn, tile%plant(pft)%plitt_af, outaCveg2lit(pft,jpngr), outaNveg2lit(pft,jpngr), scale = real(tile%plant(pft)%nind)
     call orgmv( lb_turn, lb_turn, tile%soil%plitt_af, scale = real(tile%plant(pft)%nind) )
 
   end subroutine turnover_labl

--- a/src/wrappersc.c
+++ b/src/wrappersc.c
@@ -163,6 +163,8 @@ void F77_NAME(cnmodel_f)(
     int    *secs_per_tstep,
     int    *in_ppfd,
     int    *in_netrad,
+    int    *use_prescribed_fapar,
+    int    *use_prescribed_lai,
     int    *outdt,
     int    *ltre,
     int    *ltne,
@@ -192,6 +194,8 @@ extern SEXP cnmodel_f_C(
     SEXP secs_per_tstep,
     SEXP in_ppfd,
     SEXP in_netrad,
+    SEXP use_prescribed_fapar,
+    SEXP use_prescribed_lai,
     SEXP outdt,
     SEXP ltre,
     SEXP ltne,
@@ -227,6 +231,8 @@ extern SEXP cnmodel_f_C(
         INTEGER(secs_per_tstep),
         LOGICAL(in_ppfd),
         LOGICAL(in_netrad),
+        LOGICAL(use_prescribed_fapar),
+        LOGICAL(use_prescribed_lai),
         INTEGER(outdt),
         LOGICAL(ltre),
         LOGICAL(ltne),
@@ -377,7 +383,7 @@ extern SEXP biomee_f_C(
 /////////////////////////////////////////////////////////////
 static const R_CallMethodDef CallEntries[] = {
   {"pmodel_f_C",         (DL_FUNC) &pmodel_f_C,          24},  // Specify number of arguments to C wrapper as the last number here
-  {"cnmodel_f_C",        (DL_FUNC) &cnmodel_f_C,         24},  // Specify number of arguments to C wrapper as the last number here
+  {"cnmodel_f_C",        (DL_FUNC) &cnmodel_f_C,         26},  // Specify number of arguments to C wrapper as the last number here
   {"pmodel_onestep_f_C", (DL_FUNC) &pmodel_onestep_f_C,   3},  // Specify number of arguments to C wrapper as the last number here
   {"biomee_f_C",         (DL_FUNC) &biomee_f_C,          46},  // Number of the SEXP variables (not the output)
   { NULL,                 NULL,                          0 }


### PR DESCRIPTION
## Description

This PR adds optional prescribed fAPAR and LAI forcing to the CN-model while retaining the existing internally simulated canopy dynamics as the default.

The implementation allows four configurations:

- internal fAPAR + internal LAI
- prescribed fAPAR + internal LAI
- internal fAPAR + prescribed LAI
- prescribed fAPAR + prescribed LAI

### Prescribed fAPAR

When enabled, fAPAR from the forcing is used directly for the GPP calculation instead of the internally diagnosed fAPAR.

### Prescribed LAI

LAI is added as an additional forcing variable. When prescribed LAI is enabled, the model adjusts leaf biomass toward the prescribed LAI while maintaining consistency with the existing CN-model leaf-trait relationships.

An inverse LAI-to-leaf-C calculation was added for this purpose.
If prescribed LAI requires additional leaf biomass, the increase is constrained by available labile C and, in the coupled C–N mode, by available labile N. If prescribed LAI is below the current model state, additional leaf turnover reduces the leaf pool toward the prescribed target.

Thus, prescribed LAI acts as a target constrained by available plant resources rather than directly overwriting the model's carbon and nitrogen pools.

### Implementation

The R/C/Fortran interface was extended with:

- `use_prescribed_fapar`
- `use_prescribed_lai`
- an additional LAI forcing column

### Testing

All four configurations were tested.

The separation between prescribed fAPAR and prescribed LAI was also checked. In particular, switching prescribed LAI on while keeping prescribed fAPAR enabled leaves GPP, Vcmax25, and dark respiration unchanged directly, while changing the internally diagnosed fAPAR and vegetation carbon pools.

This confirms that prescribed LAI affects the CN-model state without inadvertently replacing the prescribed fAPAR used for GPP.