### PR TITLE
Reduce cluster export overhead in calib_sofun_lhs

### DIFF
--- a/R/calib_sofun_lhs.R
+++ b/R/calib_sofun_lhs.R
@@ -202,8 +202,13 @@ calib_sofun_lhs <- function(
     # in a likelihood cannot leave orphan worker processes behind.
     cluster <- parallel::makeCluster(n_workers)
     on.exit(try(parallel::stopCluster(cluster), silent = TRUE), add = TRUE)
-    # Export the large closure once rather than serializing drivers and
-    # observations again for every progress chunk.
+    # Export required objects separately to avoid costly closure transfer.
+    parallel::clusterExport(
+      cluster,
+      c("pars", "par_calib", "model_error", "draws", "dots", "likelihood"),
+      envir = environment()
+    )
+    # Export the worker function after its dependencies are available.
     parallel::clusterExport(cluster, "evaluate_one", envir = environment())
   }
   log_likelihood <- numeric(n_samples)


### PR DESCRIPTION
This fixes a substantial slowdown in parallel calibration using the [CN-model calibration vignette](https://github.com/geco-bern/rsofun/blob/cnmodel/vignettes/calibration_cmodel_ch_oe1.Rmd), caused by exporting the large `evaluate_one` closure to the cluster workers.

The issue became evident for longer calibration periods (approximately >10 years) in tests with the CZ-STn and CZ-BK1 sites. With 120 workers, extending the calibration period from 2010–2019 to 2010–2020 increased the `clusterExport` time from about 6.8 s to 237 s, i.e. roughly a 35× increase.

The required objects are now exported explicitly first, followed by the worker function itself. This avoids the costly serialization and transfer of the large closure and its captured environment, removing the excessive `clusterExport` time observed for longer calibration periods.

The calibration logic itself is unchanged; this only improves the efficiency of the parallel execution.